### PR TITLE
Add project proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,14 @@ This repository contains the code and documentation of an expl3 static analysis 
 3. [Related work][3]
 4. [Design][4]
 
+On September 6, 2024, the tool has been [accepted for funding][5] by [the TeX Development Fund][6]. The full text of the project proposal, which summarizes devlog posts 1–4 is available [here][7].
+
 In the future, this repository may also contain the code of other useful development tools for expl3 programmers, such as a command-line utility similar to `grep` that will ignore whitespaces and newlines as well as other tools.
 
  [1]: https://witiko.github.io/Expl3-Linter-1/
  [2]: https://witiko.github.io/Expl3-Linter-2/
  [3]: https://witiko.github.io/Expl3-Linter-3/
  [4]: https://witiko.github.io/Expl3-Linter-4/
+ [5]: https://tug.org/tc/devfund/grants.html
+ [6]: https://tug.org/tc/devfund/application.html
+ [7]: https://github.com/Witiko/expltools/releases/download/latest/project-proposal.pdf

--- a/docs/expltools/explcheck/project-proposal/01-introduction.md
+++ b/docs/expltools/explcheck/project-proposal/01-introduction.md
@@ -1,0 +1,28 @@
+# Introduction
+
+In 2021, I used [the expl3 programming language][7] for the first time in my life. I had already been eyeing expl3 for some time and, when it came to defining a `\LaTeX`{=tex}-specific interface for processing YAML metadata in [version 2.11.0][1] of [the Markdown package for `\TeX`{=tex}][2], I took the plunge.
+
+After two and a half years, approximately 3.5k out of the 5k lines of `\TeX`{=tex} code in [version 3.5.0][3] of the Markdown package are written in expl3. I also developed several consumer products with it, and I have written [three][4] [journal][5] [articles][6] for my local `\TeX`{=tex} users group about it. Needless to say, expl3 has been a blast for me!
+
+In the Markdown package, each change is reviewed by a number of automated static analysis tools (so-called *linters*), which look for programming errors in the code. While these tools don't catch all programming errors, they have proven extremely useful in catching the typos that inevitably start trickling in after 2AM.
+
+Since the Markdown package contains code in different programming languages, we use many different linters such as [`shellcheck`][8] for shell scripts, [`luacheck`][9] for Lua, and [`flake8`][10] and [`pytype`][11] for Python. However, since no linters for expl3 exist, typos are often only caught by regression tests, human reviewers, and sometimes even by our users after a release. Nobody is happy about this.
+
+Earlier this year, I realized that, unlike `\TeX`{=tex}, expl3 has the following two properties that seem to make it well-suited to static analysis:
+
+1. Simple uniform syntax: (Almost) all operations are expressed as function calls. This Lisp-like quality makes is easy to convert well-behaved expl3 programs that only use high-level interfaces into abstract syntax trees. This is a prerequisite for accurate static analysis.
+2. Explicit type and scope: Variables and constants are separate from functions. Each variable is either local or global. Variables and constants are explicitly typed. This information makes it easy to detect common programming errors related to the incorrect use of variables.
+
+For the longest time, I wanted to try my hand at building a linter from the ground up. Therefore, I decided to kill two birds with one stone and improve the tooling for expl3 while learning something new along the way by building a linter for expl3.
+
+ [1]: https://github.com/Witiko/markdown/releases/tag/2.11.0
+ [2]: https://ctan.org/pkg/markdown
+ [3]: https://github.com/Witiko/markdown/releases/tag/3.5.0
+ [4]: http://dx.doi.org/10.5300/2022-1-4/35
+ [5]: http://dx.doi.org/10.5300/2023-1-2/3
+ [6]: http://dx.doi.org/10.5300/2023-3-4/153
+ [7]: http://mirrors.ctan.org/macros/latex/required/l3kernel/expl3.pdf
+ [8]: https://www.shellcheck.net/
+ [9]: https://github.com/mpeterv/luacheck
+ [10]: https://pypi.org/project/flake8/
+ [11]: https://pypi.org/project/pytype/

--- a/docs/expltools/explcheck/project-proposal/02-requirements.md
+++ b/docs/expltools/explcheck/project-proposal/02-requirements.md
@@ -1,0 +1,106 @@
+# Requirements
+
+In this section, I outline the requirements for the linter. These will form the basis of the design and the implementation.
+
+## Functional requirements
+
+The linter should accept a list of input expl3 files. Then, the linter should process each input file and print out issues it has identified with the file.
+
+Initially, the linter should recognize at least the following types of issues:
+
+- Style:
+  - Overly long lines
+  - Missing stylistic white-spaces
+  - Malformed names of functions, variables, constants, quarks, and scan marks
+- Functions:
+  - Multiply defined functions and function variants
+  - Calling undefined functions and function variants
+  - Calling [deprecated and removed][2] functions
+  - Unknown argument specifiers
+  - Unexpected function call arguments
+  - Unused private functions and function variants
+- Variables:
+  - Multiply declared variables and constants
+  - Using undefined variables and constants
+  - Using variables of incompatible types
+  - Using deprecated and removed variables and constants
+  - Setting constants and undeclared variables
+  - Unused variables and constants
+  - Locally setting global variables and vice versa
+
+## Non-functional requirements
+
+### Issues
+
+The linter should make distinction between two types of issues: warnings and errors. As a rule of thumb, whereas warnings are suggestions about best practices, errors will likely result in runtime errors.
+
+Here are three examples of warnings:
+
+- Missing stylistic white-spaces around curly braces
+- Using deprecated functions and variables
+- Unused variable or constant
+
+Here are three examples of errors:
+
+- Using an undefined message
+- Calling a function with a `V`-type argument with a variable or constant that does not support `V`-type expansion
+- Multiply declared variable or constant
+
+The overriding design goal for the initial releases of the linter should be the simplicity of implementation and robustness to unexpected input. For all issues, the linter should prefer [precision over recall][1] and only print them out when it is reasonably certain that it has understood the code, even at the expense of potentially missing some issues.
+
+Each issue should be assigned a unique identifier. Using these identifiers, issues can be disabled globally using a config file, for individual input files from the command-line, and for sections of code or individual lines of code using `\TeX`{=tex} comments.
+
+### Architecture
+
+To make the linter easy to use in continuous integration pipelines, it should be written in Lua 5.3 using just the standard Lua library. One possible exception is checking whether functions, variables, and other symbols from the input files are expl3 build-ins. This may require using the `texlua` interpreter and a minimal `\TeX`{=tex} distribution that includes the `\LaTeX`{=tex}3 kernel, at least initially.
+
+The linter should process input files in a series of discrete steps, which should be represented as Lua modules. Users should be able to import the modules into their Lua code and use them independently on the rest of the linter.
+
+Each step should process the input received from the previous step, identify any issues with the input, and transform the input to an output format appropriate for the next step. The default command-line script for the linter should execute all steps and print out issues from all steps. Users should be able to easily adapt the default script in the following ways:
+
+1. Change how the linter discovers input files.
+2. Change or replace processing steps or insert additional steps.
+3. Change how the linter reacts to issues with the input files.
+
+The linter should integrate easily with text editors. Therefore, the linter should either directly support the [language server protocol (LSP)][6] or be designed in a way that makes it easy to write an LSP wrapper for it.
+
+### Validation
+
+As a part of the test-driven development paradigm, all issues identified by a processing step should have at least one associated test in the code repository of the linter. All tests should be executed periodically during the development of the linter.
+
+As a part of the dogfooding paradigm, the linter should be used in the continuous integration pipeline of [the Markdown Package for `\TeX`{=tex}][3] since the initial releases of the linter in order to collect early user feedback. Other early adopters are also welcome to try the initial releases of the linter and report issues to its code repository.
+
+At some point, a larger-scale validation should be conducted as an experimental part of a TUGboat article that will introduce the linter to the wider `\TeX`{=tex} community. In this validation, all expl3 packages from current and historical `\TeX`{=tex} Live distributions should be processed with the linter. The results should be evaluated both quantitatively and qualitatively. While the quantitative evaluation should focus mainly on trends in how expl3 is used in packages, the qualitative evaluation should explore the shortcomings of the linter and ideas for future improvements.
+
+### License terms
+
+The linter should be [free software][8] and dual-licensed under [the GNU General Public License (GNU GPL) 2.0][12] or later and [the `\LaTeX`{=tex} Project Public License (LPPL) 1.3c][13] or later.
+
+The option to use GNU GPL 2.0 or later is motivated by the fact that GNU GPL 2.0 and 3.0 are [mutually incompatible][14]. Supporting both GNU GPL 2.0 and 3.0 extends the number of free open-source projects that will be able to alter and redistribute the linter.
+
+The option to use LPPL 1.3c is motivated by the fact that it imposes very few licensing restrictions on `\TeX`{=tex} users. Furthermore, it also preserves the integrity of `\TeX`{=tex} distributions by enforcing its naming and maintenance clauses, which ensure ongoing project stewardship and prevent confusion between modified and official versions.
+
+Admittedly, GNU GPL and LPPL may seem like an unusual combination, since GNU GPL is a copyleft license whereas LPPL is a permissive license. However, there are strategic benefits to offering both.
+
+We would offer LPPL as the primary license for derivative works within the `\TeX`{=tex} ecosystem. One downside of using LPPL is that it could potentially allow bad actors to create proprietary derivative works without contributing back to the original project. However, this trade-off helps maintain the `\TeX`{=tex} ecosystem's consistency and reliability. Incidentally, there is an element of trust in the `\TeX`{=tex} user community to voluntarily contribute improvements back, even though the license itself does not mandate it.
+
+We would offer GNU GPL as an alternative license for derivative works outside the `\TeX`{=tex} ecosystem. The key benefit of including GNU GPL is that it enables the code to be integrated into free open-source projects, especially those with licenses that are incompatible with LPPL's naming requirements. This opens the door for broader collaboration with the free software community.
+
+Notably, GNU GPL creates a one-way licensing situation: Once a derivative work is licensed under GNU GPL, it cannot be legally re-licensed under a less restrictive license like LPPL. As a result, we wouldn't be able to incorporate changes made to GNU GPL-licensed works back into the original project under LPPL without also creating two forks of the project licensed under GNU GPL 2.0 and GNU GPL 3.0, respectively. While this might seem like a downside, I view it as an important counterbalance to the potential for proprietary derivative works under LPPL.
+
+In summary, this dual-licensing approach allows us to maintain the integrity of the `\TeX`{=tex} ecosystem while making the project more accessible to the broader free open-source community. It provides flexibility for different use cases, though we will need to carefully manage contributions to ensure compliance with all licenses.
+
+ [1]: https://developers.google.com/machine-learning/crash-course/classification/precision-and-recall
+ [2]: https://github.com/latex3/latex3/blob/main/l3kernel/doc/l3obsolete.txt
+ [3]: https://github.com/witiko/markdown
+ [4]: /Expl3-Linter-1
+ [5]: /Expl3-Linter-2.5
+ [6]: https://microsoft.github.io/language-server-protocol/
+ [7]: https://www.gnu.org/licenses/lgpl-3.0.en.html
+ [8]: https://www.gnu.org/philosophy/free-sw.html
+ [9]: https://www.gnu.org/licenses/gpl-3.0.html
+ [10]: https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses
+ [11]: /Expl3-Linter-3
+ [12]: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ [13]: https://www.latex-project.org/lppl/lppl-1-3c/
+ [14]: https://www.gnu.org/licenses/rms-why-gplv3.en.html

--- a/docs/expltools/explcheck/project-proposal/03-related-work.md
+++ b/docs/expltools/explcheck/project-proposal/03-related-work.md
@@ -1,0 +1,64 @@
+# Related work
+
+In this section, I review the related work in the analysis of `\TeX`{=tex} programs and documents. This related work should be considered in the design of the linter and reused whenever it is appropriate and compatible with the license of the linter.
+
+## Unravel
+
+[The unravel package][11] by Bruno Le Floch analyses of expl3 programs as well as `\TeX`{=tex} programs and documents in general. The package was suggested to me as related work by Joseph Wright in personal correspondence.
+
+Unlike a linter, which performs _static_ analysis by leafing through the code and makes suggestions, unravel is a _debugger_ that is used for _dynamic_ analysis. It allows the user to step through the execution of code while providing extra information about the state of `\TeX`{=tex}. Unravel is written in expl3 and emulates `\TeX`{=tex} primitives using expl3 functions. It has been released under the `\LaTeX`{=tex} Project Public License (LPPL) 1.3c.
+
+While both linters and debuggers are valuable in producing bug-free software, linters prevent bugs by proactively pointing out potential bugs without any user interaction, whereas debuggers are typically used interactively to determine the cause of a bug after it has already manifested.
+
+## Chktex, chklref, cmdtrack, lacheck, match_parens, nag, and tex2tok
+
+The Comprehensive `\TeX`{=tex} Archive Network (CTAN) lists related software projects on the topics of [debuging support][12] and [`\LaTeX`{=tex} quality][13], some of which I list in this section.
+
+[The chktex package][14] by Jens T. Berger Thielemann is a linter for the static analysis of `\LaTeX`{=tex} documents. It has been written in ANSI C and released under the GNU GPL 2.0 license. The types of issues with the input files and how they are reported to the user can be configured to some extent from the command-line and using configuration files to a larger extent. Chktex is extensible and, in addition to the configuration of existing issues, it allows the definition of new types of issues using regular expressions.
+
+[The lacheck package][17] by Kresten Krab Thorup is a linter for the static analysis of `\LaTeX`{=tex} documents. Similarly to chktex, lacheck has been written in ANSI C and released under the GNU GPL 1.0 license. Unlike chktex, lacheck cannot be configured either from the command-line or using configuration files.
+
+[The chklref package][15] by Jérôme Lelong is a linter for the static analysis of `\LaTeX`{=tex} documents. It has been written in Perl and released under the GNU GPL 3.0 license. Unlike chktex, chklref focuses just on the detection of unused labels, which often accumulate over the lifetime of a `\LaTeX`{=tex} document.
+
+[The match_parens package][18] by Wybo Dekker is a linter for the static analysis of expl3 programs as well as `\TeX`{=tex} programs and documents in general. It has been written in Ruby and released under the GNU GPL 1.0 license. Unlike chktex, match_parens focuses just on the detection of mismatched paired punctuation, such as parentheses, braces, brackets, and quotation marks. As such, it can also be used for the static analysis of natural text as well as programs and documents in programming and markup languages that use paired punctuation in its syntax.
+
+[The cmdtrack package][16] by Michael John Downes is a debugger for the dynamic analysis of `\LaTeX`{=tex} documents. It has been written in `\LaTeX`{=tex} and released under the LPPL 1.0 license. It detects unused user-defined commands, which also often accumulate over the lifetime of a `\LaTeX`{=tex} document, and mentions them in the `.log` file produced during the compilation of a `\LaTeX`{=tex} document.
+
+[The nag package][19] by Ulrich Michael Schwarz is a debugger for the dynamic analysis of `\LaTeX`{=tex} documents. Similarly to cmdtrack, nag has also been written in `\LaTeX`{=tex} and released under the LPPL 1.0 license. It detects the use of obsolete `\LaTeX`{=tex} commands, document classes, and packages and mentions them in the `.log` file produced during the compilation of a `\LaTeX`{=tex} document.
+
+[The tex2tok package][20] by Jonathan Fine is a debugger for the dynamic analysis of expl3 programs as well as `\TeX`{=tex} programs and documents in general. It has been written in `\TeX`{=tex} and released under the GNU GPL 2.0 license. It executes a `\TeX`{=tex} file and produces a new `.tok` file with a list of `\TeX`{=tex} tokens in the file. Compared to static analysis, the dynamic analysis ensures correct category codes. However, it requires the execution of the `\TeX`{=tex} file, which may take long or never complete in the presence of bugs in the code.
+
+## Luacheck and flake8
+
+[Luacheck][21] by Peter Melnichenko and [flake8][22] by Tarek Ziade are linters for the static analysis of Lua and Python programs, respectively. They have been written in Lua and Python, respectively, and released under the MIT license. Both tools are widely used and should inform the design of my linter in terms of architecture, configuration, and extensibility.
+
+Similar to chktex, the types of issues with the input files and how they are reported to the user can be configured from the command-line and using configuration files. Additionally, the reporting can also be enabled or disabled in the code of the analyzed program using inline comments.
+
+Unlike luacheck, which is not extensible at the time of writing and only allows the configuration of existing issues, flake8 supports Python extensions that can add support for new types of issues.
+
+## TeXLab and digestif
+
+[TeXLab][23] by Eric and Patrick Förscher and [digestif][24] by Augusto Stoffel are [language servers][6] for the static analysis of `\TeX`{=tex} programs and documents. They have been written in Rust and Lua, respectively, and released under the GNU GPL 3.0 license.  The language servers were suggested to me as related work by Michal Hoftich at TUG 2024.
+
+Whereas `\TeX`{=tex}Lab focuses on `\LaTeX`{=tex} documents, digestif also supports other formats such as `\Hologo{ConTeXt}`{=tex} and GNU Texinfo. Neither `\TeX`{=tex}Lab nor digestif support expl3 code at the time of writing.
+
+In terms of the programming language, license, and scope, digestif seems like the most related work to my linter. However, its GNU GPL 3.0 license is incompatible with the dual license of the linter, which prohibits code reuse.
+
+ [1]: /Expl3-Linter-2
+ [2]: /Expl3-Linter-2#license-terms
+ [5]: /Expl3-Linter-2.5
+ [6]: https://microsoft.github.io/language-server-protocol/
+ [11]: https://ctan.org/pkg/unravel
+ [12]: https://ctan.org/topic/debug-supp
+ [13]: https://ctan.org/topic/latex-qual
+ [14]: https://ctan.org/pkg/chktex
+ [15]: https://ctan.org/pkg/chklref
+ [16]: https://ctan.org/pkg/cmdtrack
+ [17]: https://ctan.org/pkg/lacheck
+ [18]: https://ctan.org/pkg/match_parens
+ [19]: https://ctan.org/pkg/nag
+ [20]: https://ctan.org/pkg/tex2tok
+ [21]: https://github.com/mpeterv/luacheck
+ [22]: https://github.com/pycqa/flake8
+ [23]: https://ctan.org/pkg/texlab
+ [24]: https://ctan.org/pkg/digestif

--- a/docs/expltools/explcheck/project-proposal/04-design.md
+++ b/docs/expltools/explcheck/project-proposal/04-design.md
@@ -1,0 +1,75 @@
+# Design
+
+In this section, I outline the design of the linter and I create a code
+repository for the linter.
+
+## Processing steps
+
+As outlined in the requirements, the linter will process input files in a
+series of discrete steps, each represented by a single Lua module.
+
+Here are the individual processing steps that should be supported by the linter:
+
+1. Preprocessing: Determine which parts of the input files contain expl3 code.
+2. Lexical analysis: Convert expl3 parts of the input files into `\TeX`{=tex} tokens.
+3. Syntactic analysis: Convert `\TeX`{=tex} tokens into a tree of function calls.
+4. Semantic analysis: Determine the meaning of the different function calls.
+5. Flow analysis: Determine additional emergent properties of the code.
+
+## Warnings and errors
+
+As also outlined in the requirements, each processing step should identify
+issues with the output and produce either a warning or an error. Furthermore,
+the requirements list 16 types of issues that should be recognized by the linter
+at a minimum. Lastly, the requirements require that, as a part of the
+test-driven development paradigm, all issues identified by a processing step
+should have at least one associated test in the code repository of the linter.
+
+In [a document titled "Warnings and errors for the expl3 analysis tool"][6],
+I compiled a list of 67 warnings and errors that should be recognized by the
+initial version of the linter. For each issue, there is also an example of
+expl3 code with and without the issue. These examples can be directly converted
+to tests and used during the development of the corresponding processing steps.
+
+## Limitations
+
+Due to the dynamic nature of `\TeX`{=tex}, initial versions of the linter will make some
+naïve assumption and simplification during the analysis, such as:
+
+- Assume default expl3 [catcodes][8] everywhere.
+- Ignore non-expl3 and third-party code.
+- Do not analyze expansion and key–value calls.
+
+As a result, the initial version of the linter may not have a sufficient
+understanding of expl3 code to support proper flow analysis. Instead, the
+initial version of the linter may need to use pseudo-flow-analysis that would
+check for simple cases of the warnings and errors from flow analysis. Future
+versions of the linter should improve their code understanding to the point
+where proper flow analysis can be performed.
+
+The warnings and errors in this documents do not cover the complete expl3
+language. The limitations currently include the areas outlined in a section
+of [the document with warnings and errors][6] titled "Caveats". Future versions
+of the linter should improve the coverage.
+
+## Code repository
+
+I created a repository [`witiko/expltools`][3] titled "Development tools for
+expl3 programmers" at GitHub. As outlined in the requirements, I dual-license the code under [GNU GPL 2.0][10] or later and [LPPL 1.3c][11] or later.
+
+Furthermore, I also [registered][7] the expl3 prefix `expltools`, so that it
+can be used in the documentation for the linter, in other supporting expl3 code
+used in the linter, and also possibly in development tools for expl3
+programmers other than the linter.
+
+ [1]: /Expl3-Linter-2
+ [2]: /Expl3-Linter-3
+ [3]: https://github.com/Witiko/expltools
+ [4]: https://github.com/astoff/digestif/blob/7962d25/digestif/Parser.lua
+ [5]: https://ctan.org/pkg/digestif
+ [6]: https://github.com/Witiko/expltools/releases/download/latest/warnings-and-errors.pdf
+ [7]: https://github.com/latex3/latex3/pull/1556
+ [8]: https://en.wikibooks.org/wiki/TeX/catcode
+ [9]: /Expl3-Linter-2#license-terms
+ [10]: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ [11]: https://www.latex-project.org/lppl/lppl-1-3c/

--- a/docs/expltools/explcheck/project-proposal/05-benefits-of-grant-funding.md
+++ b/docs/expltools/explcheck/project-proposal/05-benefits-of-grant-funding.md
@@ -1,0 +1,7 @@
+# Benefits of grant funding
+
+Securing this grant will significantly enhance my ability to dedicate focused and uninterrupted time to this project, enabling me to allocate at least two full weeks of work over the next 12 months. This concentrated effort will be far more productive than the fragmented hours I currently manage to find after a long day's work, ensuring that I can make substantial progress.
+
+Additionally, the grant will serve as a meaningful endorsement of the project's value, reflecting the community's interest and support. This recognition will not only reinforce the importance of the work but also help attract other contributors who share a commitment to advancing the project.
+
+Finally, the visibility that comes with receiving this grant will elevate the project's profile, making it more prominent within the TeX community and beyond. This increased visibility is crucial for attracting further interest, feedback, and potential collaborations, all of which are vital for the project's long-term success.

--- a/docs/expltools/explcheck/project-proposal/project-proposal.tex
+++ b/docs/expltools/explcheck/project-proposal/project-proposal.tex
@@ -1,0 +1,14 @@
+\documentclass{project-proposal}
+\begin{markdown}[snippet=metadata]
+title: 'Project proposal: expl3 static analyzer'
+author: Vít Starý Novotný
+date: September 6, 2024
+\end{markdown}
+\begin{document}
+\markdownSetup{snippet=body}
+\markdownInput{01-introduction.md}
+\markdownInput{02-requirements.md}
+\markdownInput{03-related-work.md}
+\markdownInput{04-design.md}
+\markdownInput{05-benefits-of-grant-funding.md}
+\end{document}

--- a/texmf/tex/latex/expltools/explcheck/DEPENDS.txt
+++ b/texmf/tex/latex/expltools/explcheck/DEPENDS.txt
@@ -1,6 +1,7 @@
 biber
 biblatex
 embedfile
+hologo
 hyperref
 imakeidx
 lua-widow-control

--- a/texmf/tex/latex/expltools/explcheck/markdownthemewitiko_expltools.sty
+++ b/texmf/tex/latex/expltools/explcheck/markdownthemewitiko_expltools.sty
@@ -1,0 +1,12 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesExplPackage
+  {markdownthemewitiko_expltools}%
+  {2024-09-06}%
+  {0.0.1}%
+  {Snippets for typesetting the documentation of expltools}
+\markdownSetupSnippet
+  { metadata }
+  {
+    jekyll_data,
+    expect_jekyll_data,
+  }

--- a/texmf/tex/latex/expltools/explcheck/markdownthemewitiko_expltools_explcheck_project-proposal.sty
+++ b/texmf/tex/latex/expltools/explcheck/markdownthemewitiko_expltools_explcheck_project-proposal.sty
@@ -1,0 +1,18 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesExplPackage
+  {markdownthemewitiko_expltools_explcheck_project-proposal}%
+  {2024-09-06}%
+  {0.0.1}%
+  {Snippets for typesetting the documentation of the project proposal for the expl3 analysis tool}
+\markdownSetupSnippet
+  { body }
+  {
+    raw_attribute,
+    code = {
+      \tableofcontents
+      \clearpage
+    },
+    renderers = {
+      link = { \href { #3 } { #1 } }
+    }
+  }

--- a/texmf/tex/latex/expltools/explcheck/markdownthemewitiko_expltools_explcheck_warnings-and-errors.sty
+++ b/texmf/tex/latex/expltools/explcheck/markdownthemewitiko_expltools_explcheck_warnings-and-errors.sty
@@ -1,6 +1,6 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesExplPackage
-  {markdownthemewitiko_expltools_explcheck_warnings-and-errors.sty}%
+  {markdownthemewitiko_expltools_explcheck_warnings-and-errors}%
   {2024-07-04}%
   {0.0.2}%
   {Snippets for typesetting the documentation of the warnings and errors for the expl3 analysis tool}
@@ -48,12 +48,6 @@
     \exp_args:NV
       \index
       \l__expltools_explcheck_current_label_tl
-  }
-\markdownSetupSnippet
-  { metadata }
-  {
-    jekyll_data,
-    expect_jekyll_data,
   }
 \markdownSetupSnippet
   { body }

--- a/texmf/tex/latex/expltools/explcheck/project-proposal.cls
+++ b/texmf/tex/latex/expltools/explcheck/project-proposal.cls
@@ -1,0 +1,15 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass%
+  {project-proposal}%
+  [2024-09-06 0.0.1 Document class for typesetting the project proposal for the expl3 analysis tool]
+\LoadClass{article}
+\RequirePackage{lua-widow-control}
+\RequirePackage{markdown}
+\markdownSetup {
+  import = {
+    witiko/expltools = metadata,
+    witiko/expltools/explcheck/project-proposal = body,
+  }
+}
+\RequirePackage{hologo}
+\RequirePackage{hyperref}

--- a/texmf/tex/latex/expltools/explcheck/warnings-and-errors.cls
+++ b/texmf/tex/latex/expltools/explcheck/warnings-and-errors.cls
@@ -1,7 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass%
   {warnings-and-errors}%
-  [2024-07-04 0.0.2 Documentation for typesetting the documentation of the warnings and errors for the expl3 analysis tool]
+  [2024-09-06 0.0.3 Document class for typesetting the documentation of the warnings and errors for the expl3 analysis tool]
 \LoadClass{article}
 \RequirePackage{lua-widow-control}
 \RequirePackage{minted}
@@ -9,7 +9,8 @@
 \RequirePackage{markdown}
 \markdownSetup {
   import = {
-    witiko/expltools/explcheck/warnings-and-errors = {metadata, body},
+    witiko/expltools = metadata,
+    witiko/expltools/explcheck/warnings-and-errors = body,
   }
 }
 \RequirePackage{biblatex}


### PR DESCRIPTION
Earlier today, the explcheck tool has been [accepted for funding][1] by [the TeX Development Fund][2].
This PR adds the full text of the project proposal, to be also published in the website of the TeX Development Fund.

 [1]: https://tug.org/tc/devfund/grants.html
 [2]: https://tug.org/tc/devfund/application.html