### PR TITLE
Fix various issues reported over the past week

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run explcheck
         run: |
           set -e
-          export LUA_PATH=explcheck/src/?.lua
+          export LUAINPUTS=explcheck/src
           find */support -type f '(' -name '*.tex' -o -name '*.sty' ')' -exec \
             texlua explcheck/src/explcheck.lua --warnings-are-errors {} +
   tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
             **/DEPENDS.txt
       - name: Build a CTAN archive
         run: |
+          l3build tag
           l3build ctan
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           set -e
           l3build tag
-          docker build -f explcheck/Dockerfile -t ghcr.io/${{ github.repository }}/explcheck
+          docker build -f explcheck/Dockerfile -t ghcr.io/${{ github.repository }}/explcheck .
       - name: Login to GitHub Packages
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,37 @@ jobs:
       - name: Run tests
         run: |
           l3build check
+  docker-image:
+    name: Build the Docker image
+    needs: [luacheck, explcheck, tests]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install TeX Live
+        uses: teatimeguest/setup-texlive-action@v3
+        with:
+          packages: |
+            l3build
+      - name: Build the Docker image
+        run: |
+          set -e
+          l3build tag
+          docker build -f explcheck/Dockerfile -t ghcr.io/${{ github.repository }}/explcheck
+      - name: Login to GitHub Packages
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish the Docker image
+        if: github.ref == 'refs/heads/main'
+        run: docker push ghcr.io/${{ github.repository }}/explcheck
   ctan:
-    name: Build a CTAN archive
+    name: Build the CTAN archive
     needs: [luacheck, explcheck, tests]
     runs-on: ubuntu-latest
     permissions:
@@ -75,8 +104,9 @@ jobs:
             l3build
           package-file: |
             **/DEPENDS.txt
-      - name: Build a CTAN archive
+      - name: Build the CTAN archive
         run: |
+          set -e
           l3build tag
           l3build ctan
       - name: Upload artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           set -e
           l3build tag
-          docker build -f explcheck/Dockerfile -t ghcr.io/${{ github.repository }}/explcheck .
+          docker build -f explcheck/Dockerfile -t ghcr.io/witiko/expltools/explcheck .
       - name: Login to GitHub Packages
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
@@ -81,7 +81,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish the Docker image
         if: github.ref == 'refs/heads/main'
-        run: docker push ghcr.io/${{ github.repository }}/explcheck
+        run: docker push ghcr.io/witiko/expltools/explcheck
   ctan:
     name: Build the CTAN archive
     needs: [luacheck, explcheck, tests]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@
 - Include instructions about using l3build in the file `README.md`.
   (reported in #11, added in #13)
 
+#### Continuous integration
+
+- Add `Dockerfile`, create Docker image, and mention it in the file `README.md`.
+  (discussed in #12, added in #13)
+
 ## expltools 2024-12-04
 
 ### explcheck v0.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,13 @@
  [tex-live-02]: https://tug.org/pipermail/tex-live/2024-December/050958.html
  [tex-live-03]: https://tug.org/pipermail/tex-live/2024-December/050968.html
 
+#### Documentation
+
 - Include explcheck version in the command-line interface.
   (reported in #10, fixed in #13)
+
+- Hint in the file `README.md` that .dtx are not well supported.
+  (reported by @josephwright in #8, added in #13)
 
 ## expltools 2024-12-04
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## expltools 2024-12-09
+
+### explcheck v0.1.1
+
+### Fixes
+- In LuaTeX, initialize Kpathsea Lua module searchers first.
+  (#9, #13, contributed by @gucci-on-fleek)
+
 ## expltools 2024-12-04
 
 ### explcheck v0.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### explcheck v0.1.1
 
-### Fixes
+#### Fixes
 
 - In LuaTeX, initialize Kpathsea Lua module searchers first.
 
@@ -17,6 +17,9 @@
 
  [tex-live-02]: https://tug.org/pipermail/tex-live/2024-December/050958.html
  [tex-live-03]: https://tug.org/pipermail/tex-live/2024-December/050968.html
+
+- Include explcheck version in the command-line interface.
+  (reported in #10, fixed in #13)
 
 ## expltools 2024-12-04
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
 - Hint in the file `README.md` that .dtx are not well supported.
   (reported by @josephwright in #8, added in #13)
 
+- Show in the file `README.md` how explcheck can be used from Lua code. (#13)
+
 ## expltools 2024-12-04
 
 ### explcheck v0.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,25 +5,42 @@
 ### explcheck v0.1.1
 
 ### Fixes
+
 - In LuaTeX, initialize Kpathsea Lua module searchers first.
-  (#9, #13, contributed by @gucci-on-fleek)
+
+  (reported by @josephwright, Lars Madsen, and Philip Taylor on
+  [tex-live@tug.org][tex-live-02] and by @muzimuzhi in #9,
+  fixed on [tex-live@tug.org][tex-live-03] by @gucci-on-fleek)
+
+- Allow spaces between arguments of `\ProvidesExpl*` commands.
+  (reported by @u-fischer and @josephwright in #7, fixed in #13)
+
+ [tex-live-02]: https://tug.org/pipermail/tex-live/2024-December/050958.html
+ [tex-live-03]: https://tug.org/pipermail/tex-live/2024-December/050968.html
 
 ## expltools 2024-12-04
 
 ### explcheck v0.1
 
 #### Development
+
 - Implement preprocessing. (#5)
 
 #### Documentation
-- Add `README.md`. (#1, #2, suggested by @Skillmon)
+
+- Add `README.md`. (suggested by @Skillmon in #1, fixed in #2)
 - Update to Markdown 3. (#3)
 - Use the expl3 prefix `expltools`. (#3)
 - Add project proposal. (#4)
 
 #### Continuous integration
+
 - Use small Docker image. (#3)
 
 #### Distribution
-- Make changes to the CTAN archive following a discussion with TeX Live and CTAN maintainers.
-  (#6, many thanks to Petra Rübe-Pugliese, Reinhard Kotucha, and Zdeněk Wagner)
+
+- Make changes to the CTAN archive following a discussion with TeX Live developers
+  on [tex-live@tug.org][tex-live-01] and with CTAN maintainers. Many thanks
+  specifically to Petra Rübe-Pugliese, Reinhard Kotucha, and Zdeněk Wagner.
+
+ [tex-live-01]: https://tug.org/pipermail/tex-live/2024-December/050952.html

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@
 
 - Show in the file `README.md` how explcheck can be used from Lua code. (#13)
 
+- Include instructions about using l3build in the file `README.md`.
+  (reported in #11, added in #13)
+
 ## expltools 2024-12-04
 
 ### explcheck v0.1

--- a/README.md
+++ b/README.md
@@ -30,6 +30,35 @@ You can use the tool from command-line as follows:
 $ explcheck [options] [.tex, .cls, and .sty files]
 ```
 
+You can also use the tool from your own Lua code by importing the corresponding files `explcheck-*.lua`:
+
+``` lua
+local new_issues = require("explcheck-issues")
+local preprocessing = require("explcheck-preprocessing")
+
+-- LuaTeX users must initialize Kpathsea Lua module searchers first.
+local using_luatex, kpse = pcall(require, "kpse")
+if using_luatex then
+  kpse.set_program_name("texlua", "explcheck")
+end
+
+-- Apply the preprocessing step to a file "code.tex".
+local filename = "code.tex"
+local issues = new_issues()
+
+local file = assert(io.open(filename, "r"))
+local content = assert(file:read("*a"))
+assert(file:close())
+
+local line_starting_byte_numbers = preprocessing(issues, content)
+
+print(
+  "There were " .. #issues.warnings .. " warnings "
+  .. "and " .. #issues.errors .. " errors "
+  .. "in the file " .. filename .. "."
+)
+```
+
 ## Notes to distributors
 
 The file `explcheck.lua` should be installed in the TDS directory `scripts/expltools/explcheck`. Furthermore, it should be made executable and either symlinked to system directories as `explcheck` on Unix or have a wrapper `explcheck.exe` installed on Windows.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In the future, this repository may also contain the code of other useful develop
 
 ## Usage
 
-You can use the tool from command-line as follows:
+You can use the tool from the command line as follows:
 
 ```
 $ explcheck [options] [.tex, .cls, and .sty files]
@@ -60,6 +60,11 @@ print(
 ```
 
 ## Notes to distributors
+
+You can prepare the expltools bundle for distribution with the following two commands:
+
+- `l3build tag`: Add the current version numbers to the file `explcheck-lua.cli`.
+- `l3build ctan`: Run tests, build the documentation, and create a CTAN archive `expltools-ctan.zip`.
 
 The file `explcheck.lua` should be installed in the TDS directory `scripts/expltools/explcheck`. Furthermore, it should be made executable and either symlinked to system directories as `explcheck` on Unix or have a wrapper `explcheck.exe` installed on Windows.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ You can use the tool from the command line as follows:
 $ explcheck [options] [.tex, .cls, and .sty files]
 ```
 
-You can also use the tool from your own Lua code by importing the corresponding files `explcheck-*.lua`:
+You can also use the tool from your own Lua code by importing the corresponding files `explcheck-*.lua`.
+For example, here is Lua code that applies the preprocessing step to the code from a file named `code.tex`:
 
 ``` lua
 local new_issues = require("explcheck-issues")
@@ -57,6 +58,23 @@ print(
   .. "and " .. #issues.errors .. " errors "
   .. "in the file " .. filename .. "."
 )
+```
+
+You can also use the tool from continuous integration workflows using the Docker image `ghcr.io/witiko/expltools/explcheck`.
+For example, here is a GitHub Actions workflow file that applies the tool to all .tex file in a Git repository:
+
+``` yaml
+name: Check expl3 code
+on:
+  push:
+jobs:
+  typeset:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/witiko/expltools/explcheck
+    steps:
+      - uses: actions/checkout@v4
+      - run: explcheck *.tex
 ```
 
 ## Notes to distributors

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In the future, this repository may also contain the code of other useful develop
 You can use the tool from command-line as follows:
 
 ```
-$ explcheck [options] [filenames]
+$ explcheck [options] [.tex, .cls, and .sty files]
 ```
 
 ## Notes to distributors

--- a/build.lua
+++ b/build.lua
@@ -37,7 +37,7 @@ end
 -- A custom main function
 function main(target, names)
   local return_value
-  if ({check=true, bundlecheck=true, doc=true})[target] ~= nil then
+  if ({check=true, bundlecheck=true, doc=true, tag=true})[target] ~= nil then
     return_value = call(modules, target)
   elseif ({ctan=true, bundlectan=true})[target] ~= nil then
     return_value = target_list[target].bundle_func(names)

--- a/explcheck/Dockerfile
+++ b/explcheck/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+RUN apk add --no-cache lua5.3 lua5.3-lpeg
+RUN mkdir -p /opt/expltools/explcheck
+COPY explcheck/src/*.lua /opt/expltools/explcheck/
+COPY <<'EOF' /usr/local/bin/explcheck
+#!/bin/sh
+export LUA_PATH=/opt/expltools/explcheck/?.lua
+lua5.3 /opt/expltools/explcheck/explcheck.lua "$@"
+EOF
+RUN chmod +x /usr/local/bin/explcheck
+ENTRYPOINT ["explcheck"]

--- a/explcheck/build.lua
+++ b/explcheck/build.lua
@@ -32,6 +32,9 @@ typesetsuppfiles = {
 scriptfiles = {
   "explcheck.lua",
 }
+tagfiles = {
+  "explcheck-cli.lua",
+}
 
 -- Convert a pathname of a file to the base name of a file.
 local function get_suffix(filename)
@@ -69,10 +72,27 @@ local function bundlectan()
   return 0
 end
 
+-- Determine the latest version of the tool from the file `CHANGES.md`.
+local function get_latest_explcheck_version()
+  local pattern = "^%s*#%s*#%s*#%s*explcheck%s*"
+  for line in io.lines(maindir .. "/CHANGES.md") do
+    if line:find(pattern) then
+      return line:gsub(pattern, "")
+    end
+  end
+  assert(false)
+end
+
+function update_tag(file, content, tagname, tagdate)
+  tagname = tagname or get_latest_explcheck_version()
+  return content:gsub("${VERSION}", tagname)
+                :gsub("${DATE}", tagdate)
+end
+
 -- A custom main function
 function main(target, names)
   local return_value
-  if ({check=true, bundlecheck=true, ctan=true, bundlectan=true, doc=true})[target] ~= nil then
+  if ({check=true, bundlecheck=true, ctan=true, bundlectan=true, doc=true, tag=true})[target] ~= nil then
     local func = target == "bundlectan" and bundlectan or target_list[target].func
     return_value = func(names)
     if ({ctan=true, bundlectan=true, doc=true})[target] ~= nil then

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -76,6 +76,12 @@ local function print_usage()
   print("\t--warnings-are-errors\tProduce a non-zero exit code if any warnings are produced by the analysis.")
 end
 
+local function print_version()
+  print("explcheck (expltools ${DATE}) ${VERSION}")
+  print("Copyright (c) 2024 Vít Starý Novotný")
+  print("Licenses: LPPL 1.3 or later, GNU GPL v2 or later")
+end
+
 if #arg == 0 then
   print_usage()
   os.exit(1)
@@ -90,8 +96,11 @@ else
       table.insert(pathnames, argument)
     elseif argument == "--" then
       only_pathnames_from_now_on = true
-    elseif argument == "--help" then
+    elseif argument == "--help" or argument == "-h" then
       print_usage()
+      os.exit(0)
+    elseif argument == "--version" or argument == "-v" then
+      print_version()
       os.exit(0)
     elseif argument == "--warnings-are-errors" then
       warnings_are_errors = true

--- a/explcheck/src/explcheck-preprocessing.lua
+++ b/explcheck/src/explcheck-preprocessing.lua
@@ -26,7 +26,7 @@ local newline = (
 local linechar = any - newline
 local spacechar = S("\t ")
 local optional_spaces = spacechar^0
-local optional_spaces_and_newline_after_cs = (
+local optional_spaces_and_newline = (
   optional_spaces
   * (
     newline
@@ -65,13 +65,16 @@ local provides = (
       + P("Class")
       + P("File")
     )
-  * optional_spaces_and_newline_after_cs
+  * optional_spaces_and_newline
   * comment^0
   * argument
+  * optional_spaces_and_newline
   * comment^0
   * argument
+  * optional_spaces_and_newline
   * comment^0
   * argument
+  * optional_spaces_and_newline
   * comment^0
   * argument
 )

--- a/explcheck/src/explcheck.lua
+++ b/explcheck/src/explcheck.lua
@@ -1,3 +1,7 @@
 #!/usr/bin/env texlua
 -- A command-line interface for the static analyzer explcheck.
+local using_luatex, kpse = pcall(require, "kpse")
+if using_luatex then
+  kpse.set_program_name("texlua", "explcheck")
+end
 require("explcheck-cli")

--- a/explcheck/test.lua
+++ b/explcheck/test.lua
@@ -7,6 +7,11 @@ local function get_basename(filename)
   return filename:gsub(".+/", "")
 end
 
+-- Convert a pathname of a file to the stem of a file.
+local function get_stem(filename)
+  return get_basename(filename):gsub("%..*", "")
+end
+
 -- Convert a pathname of a file to the suffix of a file.
 local function get_suffix(filename)
   return filename:gsub(".*%.", ".")
@@ -50,7 +55,7 @@ local function run_tests(test_directory, support_files, test_files)
   end
   table.sort(lua_test_files, function(a, b)
     local a_number, b_number = tonumber(get_basename(a):sub(2, 4)), tonumber(get_basename(b):sub(2, 4))
-    return a_number < b_number or (a_number == b_number and a < b)
+    return a_number < b_number or (a_number == b_number and get_stem(a) < get_stem(b))
   end)
 
   -- Run the tests.

--- a/explcheck/testfiles/w100-01.lua
+++ b/explcheck/testfiles/w100-01.lua
@@ -1,0 +1,14 @@
+local new_issues = require("explcheck-issues")
+local preprocessing = require("explcheck-preprocessing")
+
+local filename = "w100-01.tex"
+
+local file = assert(io.open(filename, "r"))
+local content = assert(file:read("*a"))
+assert(file:close())
+local issues = new_issues()
+
+preprocessing(issues, content)
+
+assert(#issues.errors == 0)
+assert(#issues.warnings == 0)

--- a/explcheck/testfiles/w100-01.tex
+++ b/explcheck/testfiles/w100-01.tex
@@ -1,0 +1,1 @@
+\ProvidesExplFile {example.tex} {2024-04-09} {1.0.0} {An example file}

--- a/explcheck/testfiles/w100-02.lua
+++ b/explcheck/testfiles/w100-02.lua
@@ -1,0 +1,14 @@
+local new_issues = require("explcheck-issues")
+local preprocessing = require("explcheck-preprocessing")
+
+local filename = "w100-02.tex"
+
+local file = assert(io.open(filename, "r"))
+local content = assert(file:read("*a"))
+assert(file:close())
+local issues = new_issues()
+
+preprocessing(issues, content)
+
+assert(#issues.errors == 0)
+assert(#issues.warnings == 0)

--- a/explcheck/testfiles/w100-02.tex
+++ b/explcheck/testfiles/w100-02.tex
@@ -1,0 +1,2 @@
+\ProvidesExplPackage {tagpdf} {2024-12-04} {0.99k}
+  { LaTeX kernel code for PDF tagging }


### PR DESCRIPTION
This PR makes the following changes:
- In LuaTeX, initialize Kpathsea Lua module searchers first.
- Allow spaces between arguments of `\ProvidesExpl*` commands.
- Include explcheck version in the command-line interface.
- Hint in the file `README.md` that .dtx are not well supported.
- Show in the file `README.md` how explcheck can be used from Lua code.
- Include instructions about using l3build in the file `README.md`.
- Add `Dockerfile`, create Docker image, and mention it in `README.md`.