### PR TITLE
Forbid checking .ins and .dtx files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,22 @@
 
 ## expltools 2024-MM-DD
 
-### explcheck v0.2.0
+### explcheck v0.1.2
+
+#### Fixes
+
+- In the command-line interface, forbid the checking of .ins and .dtx files.
+  Display messages that direct users to check the generated files instead.
+  (reported by @josephwright and @FrankMittelbach in #8, fixed in #14)
+
+- Expect both backslashes and forward slashes when shortening pathnames. (#14)
+
+- Correctly pluralize "1 file" on the first line of command-line output. (#14)
+
+#### Documentation
+
+- Normalize the behavior and documentation of functions `get_*()` across files
+  `explcheck/build.lua`, `explcheck/test.lua`, and `explcheck-cli.lua`. (#14)
 
 ## expltools 2024-12-09
 
@@ -11,7 +26,6 @@
 #### Fixes
 
 - In LuaTeX, initialize Kpathsea Lua module searchers first.
-
   (reported by @josephwright, Lars Madsen, and Philip Taylor on
   [tex-live@tug.org][tex-live-02] and by @muzimuzhi in #9,
   fixed on [tex-live@tug.org][tex-live-03] by @gucci-on-fleek)

--- a/explcheck/build.lua
+++ b/explcheck/build.lua
@@ -36,9 +36,9 @@ tagfiles = {
   "explcheck-cli.lua",
 }
 
--- Convert a pathname of a file to the base name of a file.
-local function get_suffix(filename)
-  return filename:gsub(".+%.", "."):lower()
+-- Convert a pathname of a file to the suffix of the file.
+local function get_suffix(pathname)
+  return pathname:gsub(".*%.", "."):lower()
 end
 
 -- Determine whether a filename refers to an existing file.

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -86,7 +86,7 @@ local function main(pathnames, warnings_are_errors, max_line_length)
   local num_warnings = 0
   local num_errors = 0
 
-  print("Checking " .. #pathnames .. " files")
+  print("Checking " .. #pathnames .. " " .. format.pluralize("file", #pathnames))
 
   for pathname_number, pathname in ipairs(pathnames) do
 

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -24,6 +24,63 @@ local function deduplicate_pathnames(pathnames)
   return deduplicated_pathnames
 end
 
+-- Convert a pathname of a file to the suffix of the file.
+local function get_suffix(pathname)
+  return pathname:gsub(".*%.", "."):lower()
+end
+
+-- Convert a pathname of a file to the base name of the file.
+local function get_basename(pathname)
+  return pathname:gsub(".*[\\/]", "")
+end
+
+-- Convert a pathname of a file to the pathname of its parent directory.
+local function get_parent(pathname)
+  if pathname:find("[\\/]") then
+    return pathname:gsub("(.*)[\\/].*", "%1")
+  else
+    return "."
+  end
+end
+
+-- Check that the pathname specifies a file that we can process.
+local function check_pathname(pathname)
+  local suffix = get_suffix(pathname)
+  if suffix == ".ins" then
+    local basename = get_basename(pathname)
+    if basename:find(" ") then
+      basename = "'" .. candidate_basename .. "'"
+    end
+    return
+      false,
+      "explcheck can't currently process .ins files directly\n"
+      .. 'Use a command such as "luatex ' .. basename .. '" '
+      .. "to generate .tex, .cls, and .sty files and process these files instead."
+  elseif suffix == ".dtx" then
+    local parent = get_parent(pathname)
+    local basename = "*.ins"
+    local has_lfs, lfs = pcall(require, "lfs")
+    if has_lfs then
+      for candidate_basename in lfs.dir(parent) do
+        local candidate_suffix = get_suffix(candidate_basename)
+        if candidate_suffix == ".ins" then
+          basename = candidate_basename
+          if basename:find(" ") then
+            basename = "'" .. candidate_basename .. "'"
+          end
+          break
+        end
+      end
+    end
+    return
+      false,
+      "explcheck can't currently process .dtx files directly\n"
+      .. 'Use a command such as "luatex ' .. basename .. '" '
+      .. "to generate .tex, .cls, and .sty files and process these files instead."
+  end
+  return true
+end
+
 -- Process all input files.
 local function main(pathnames, warnings_are_errors, max_line_length)
   local num_warnings = 0
@@ -114,7 +171,16 @@ else
       table.insert(pathnames, argument)
     end
   end
+
+  -- Deduplicate and check that pathnames specify files that we can process.
   pathnames = deduplicate_pathnames(pathnames)
+  for _, pathname in ipairs(pathnames) do
+    local is_ok, error_message = check_pathname(pathname)
+    if not is_ok then
+      print('Failed to process "' .. pathname .. '": ' .. error_message)
+      os.exit(1)
+    end
+  end
 
   -- Run the analysis.
   local exit_code = main(pathnames, warnings_are_errors, max_line_length)

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -49,7 +49,7 @@ local function check_pathname(pathname)
   if suffix == ".ins" then
     local basename = get_basename(pathname)
     if basename:find(" ") then
-      basename = "'" .. candidate_basename .. "'"
+      basename = "'" .. basename .. "'"
     end
     return
       false,

--- a/explcheck/src/explcheck-format.lua
+++ b/explcheck/src/explcheck-format.lua
@@ -16,9 +16,9 @@ local function format_pathname(pathname, max_length)
   while #pathname > max_length do
     local pattern
     if first_iteration then
-      pattern = "([^/]*)/[^/]*/(.*)"
+      pattern = "([^\\/]*)[\\/][^\\/]*[\\/](.*)"
     else
-      pattern = "([^/]*)/%.%.%./[^/]*/(.*)"
+      pattern = "([^\\/]*)/%.%.%.[\\/][^\\/]*[\\/](.*)"
     end
     local prefix_start, _, prefix, suffix = pathname:find(pattern)
     if prefix_start == nil or prefix_start > 1 then
@@ -31,9 +31,9 @@ local function format_pathname(pathname, max_length)
   if #pathname > max_length then
     local pattern
     if first_iteration then
-      pattern = "([^/]*/?)(.*)"
+      pattern = "([^\\/]*[\\/]?)(.*)"
     else
-      pattern = "([^/]*/%.%.%./)(.*)"
+      pattern = "([^\\/]*[\\/]%.%.%.[\\/])(.*)"
     end
     local prefix_start, _, _, suffix = pathname:find(pattern)
     if prefix_start == 1 then

--- a/explcheck/src/explcheck-format.lua
+++ b/explcheck/src/explcheck-format.lua
@@ -228,6 +228,7 @@ end
 
 return {
   convert_byte_to_line_and_column = convert_byte_to_line_and_column,
+  pluralize = pluralize,
   print_results = print_results,
   print_summary = print_summary,
 }

--- a/explcheck/test.lua
+++ b/explcheck/test.lua
@@ -2,19 +2,19 @@
 
 local lfs = require("lfs")
 
--- Convert a pathname of a file to the base name of a file.
-local function get_basename(filename)
-  return filename:gsub(".+/", "")
+-- Convert a pathname of a file to the base name of the file.
+local function get_basename(pathname)
+  return pathname:gsub(".*[\\/]", "")
 end
 
--- Convert a pathname of a file to the stem of a file.
-local function get_stem(filename)
-  return get_basename(filename):gsub("%..*", "")
+-- Convert a pathname of a file to the stem of the file.
+local function get_stem(pathname)
+  return get_basename(pathname):gsub("%..*", "")
 end
 
--- Convert a pathname of a file to the suffix of a file.
-local function get_suffix(filename)
-  return filename:gsub(".*%.", ".")
+-- Convert a pathname of a file to the suffix of the file.
+local function get_suffix(pathname)
+  return pathname:gsub(".*%.", "."):lower()
 end
 
 -- Transform a singular into plural if the count is zero or greater than two.


### PR DESCRIPTION
This PR makes the following change:

- Forbid checking .ins and .dtx files.

### Demonstration

For example, using explcheck on the file [`siunitx-unit.dtx`][1] from @josephwright's repository [siunitx][2] gives this result:

```
$ explcheck siunitx-unit.dtx
```
```
Failed to process "siunitx-unit.dtx": explcheck can't currently process .dtx files directly
Use a command such as "luatex siunitx.ins" to generate .tex, .cls, and .sty files and process these files instead.
```

A persistent user might try the following next:
```
$ explcheck siunitx.ins
```
```
Failed to process "siunitx.ins": explcheck can't currently process .ins files directly
Use a command such as "luatex siunitx.ins" to generate .tex, .cls, and .sty files and process these files instead.
```

Hopefully, these error messages will nudge the user into doing the right thing:
```
$ luatex siunitx.ins
$ explcheck siunitx.sty --max-line-length=120
```
```
Checking 1 file

Checking siunitx.sty                                                  OK

Total: 0 errors, 0 warnings in 1 file
```

In the future, we may want to support .ins and .dtx files directly, as discussed in https://github.com/Witiko/expltools/issues/8#issuecomment-2537390144 and below. However, such support is not part of the initial project requirements and there is a lot to get right with a feature like this. Therefore, this is not on my short-term radar.

---

This PR also makes the following changes:

- Normalize the behavior and documentation of functions `get_*()`.
- Expect both backslashes and forward slashes when shortening pathnames.
- Correctly pluralize 1 file / 2 files on the first line of output.

This PR continues #8.

 [1]: https://github.com/josephwright/siunitx/blob/main/siunitx-unit.dtx
 [2]: https://github.com/josephwright/siunitx