### PR TITLE
Add a command-line option `--porcelain` for machine-readable output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## expltools 2024-MM-DD
+## expltools 2024-12-13
 
 ### explcheck v0.2.0
 
@@ -8,6 +8,10 @@
 
 - Add a command-line option `--porcelain` for machine-readable output.
   (suggested by @FrankMittelbach in #8, added in #14)
+
+  See <https://github.com/Witiko/expltools/pull/15#issuecomment-2542418484>
+  and below for a demonstration of how you might set up your text editor, so
+  that it automatically navigates you to lines with warnings and errors.
 
 #### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,12 @@
 
 ## expltools 2024-MM-DD
 
-### explcheck v0.1.2
+### explcheck v0.2.0
+
+#### Development
+
+- Add a command-line option `--porcelain` for machine-readable output.
+  (suggested by @FrankMittelbach in #8, added in #14)
 
 #### Fixes
 

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -82,11 +82,13 @@ local function check_pathname(pathname)
 end
 
 -- Process all input files.
-local function main(pathnames, warnings_are_errors, max_line_length)
+local function main(pathnames, warnings_are_errors, max_line_length, porcelain)
   local num_warnings = 0
   local num_errors = 0
 
-  print("Checking " .. #pathnames .. " " .. format.pluralize("file", #pathnames))
+  if not porcelain then
+    print("Checking " .. #pathnames .. " " .. format.pluralize("file", #pathnames))
+  end
 
   for pathname_number, pathname in ipairs(pathnames) do
 
@@ -110,11 +112,13 @@ local function main(pathnames, warnings_are_errors, max_line_length)
     ::continue::
     num_warnings = num_warnings + #issues.warnings
     num_errors = num_errors + #issues.errors
-    format.print_results(pathname, issues, line_starting_byte_numbers, pathname_number == #pathnames)
+    format.print_results(pathname, issues, line_starting_byte_numbers, pathname_number == #pathnames, porcelain)
   end
 
   -- Print a summary.
-  format.print_summary(#pathnames, num_warnings, num_errors)
+  if not porcelain then
+    format.print_summary(#pathnames, num_warnings, num_errors, porcelain)
+  end
 
   if(num_errors > 0) then
     return 1
@@ -129,8 +133,9 @@ local function print_usage()
   print("Usage: " .. arg[0] .. " [OPTIONS] FILENAMES\n")
   print("Run static analysis on expl3 files.\n")
   print("Options:")
-  print("\t--max-line-length=N\tThe maximum line length before the warning S103 (Line too long) is produced.")
-  print("\t--warnings-are-errors\tProduce a non-zero exit code if any warnings are produced by the analysis.")
+  print("\t--max-line-length=N    The maximum line length before the warning S103 (Line too long) is produced.")
+  print("\t--porcelain            Produce machine-readable output.")
+  print("\t--warnings-are-errors  Produce a non-zero exit code if any warnings are produced by the analysis.")
 end
 
 local function print_version()
@@ -148,6 +153,7 @@ else
   local warnings_are_errors = false
   local only_pathnames_from_now_on = false
   local max_line_length = nil
+  local porcelain = false
   for _, argument in ipairs(arg) do
     if only_pathnames_from_now_on then
       table.insert(pathnames, argument)
@@ -161,6 +167,8 @@ else
       os.exit(0)
     elseif argument == "--warnings-are-errors" then
       warnings_are_errors = true
+    elseif argument == "--porcelain" then
+      porcelain = true
     elseif argument:sub(1, 18) == "--max-line-length=" then
       max_line_length = tonumber(argument:sub(19))
     elseif argument:sub(1, 2) == "--" then
@@ -183,6 +191,6 @@ else
   end
 
   -- Run the analysis.
-  local exit_code = main(pathnames, warnings_are_errors, max_line_length)
+  local exit_code = main(pathnames, warnings_are_errors, max_line_length, porcelain)
   os.exit(exit_code)
 end

--- a/explcheck/src/explcheck-format.lua
+++ b/explcheck/src/explcheck-format.lua
@@ -189,7 +189,7 @@ local function print_results(pathname, issues, line_starting_byte_numbers, is_la
               ), 1
             )
           )
-          line = (
+          local line = (
             label_indent
             .. formatted_pathname
             .. position

--- a/explcheck/src/explcheck-format.lua
+++ b/explcheck/src/explcheck-format.lua
@@ -95,7 +95,7 @@ local function print_results(pathname, issues, line_starting_byte_numbers, is_la
         ), 1, 31
       )
     )
-    table.insert(all_issues, issues.errors)
+    table.insert(all_issues, {issues.errors, "error: "})
     if(#issues.warnings > 0) then
       status = (
         status
@@ -108,7 +108,7 @@ local function print_results(pathname, issues, line_starting_byte_numbers, is_la
           ), 1, 33
         )
       )
-      table.insert(all_issues, issues.warnings)
+      table.insert(all_issues, {issues.warnings, "warning: "})
     end
   elseif(#issues.warnings > 0) then
     status = colorize(
@@ -118,7 +118,7 @@ local function print_results(pathname, issues, line_starting_byte_numbers, is_la
         .. pluralize("warning", #issues.warnings)
       ), 1, 33
     )
-    table.insert(all_issues, issues.warnings)
+    table.insert(all_issues, {issues.warnings, "warning: "})
   else
     status = colorize("OK", 1, 32)
   end
@@ -157,7 +157,8 @@ local function print_results(pathname, issues, line_starting_byte_numbers, is_la
 
   -- Display the errors, followed by warnings.
   if #all_issues > 0 then
-    for _, warnings_or_errors in ipairs(all_issues) do
+    for _, warnings_or_errors_and_porcelain_prefix in ipairs(all_issues) do
+      local warnings_or_errors, porcelain_prefix = table.unpack(warnings_or_errors_and_porcelain_prefix)
       if not porcelain then
         print()
       end
@@ -209,7 +210,7 @@ local function print_results(pathname, issues, line_starting_byte_numbers, is_la
           )
           io.write("\n" .. line)
         else
-          print(pathname .. position .. " " .. suffix)
+          print(pathname .. position .. " " .. porcelain_prefix .. suffix)
         end
       end
     end


### PR DESCRIPTION
This PR makes the following changes:

- Add a command-line option `--porcelain` for machine-readable output.

### Demonstration

```
$ git clone https://github.com/witiko/expltools
$ git checkout feat/porcelain
$ cd expltools/explcheck/src
$ ./explcheck.lua ../testfiles/e102.tex
```
```
Checking 1 file

Checking ../testfiles/e102.tex                                  2 errors

    ../testfiles/e102.tex:11:1:          E102 expl3 control sequences in non-expl3 parts
    ../testfiles/e102.tex:12:3:          E102 expl3 control sequences in non-expl3 parts

Total: 2 errors, 0 warnings in 1 file
```
```
$ ./explcheck.lua ../testfiles/e102.tex --porcelain
```
```
../testfiles/e102.tex:11:1: E102 expl3 control sequences in non-expl3 parts
../testfiles/e102.tex:12:3: E102 expl3 control sequences in non-expl3 parts
```

---

This change was made after a discussion with @FrankMittelbach in https://github.com/Witiko/expltools/issues/8#issuecomment-2540071418 and below. It should enable better integration with text editors in the absence of language sever protocol (LSP) support in this early version of explcheck, as discussed in https://github.com/Witiko/expltools/issues/8#issuecomment-2541737424.

I will test this change with Vim and emacs later today and will post screenshots as an interim documentation of the feature. Please, let me know if this is what you had in mind, @FrankMittelbach.

This PR closes ticket https://github.com/Witiko/expltools/issues/8, together with pull requests https://github.com/Witiko/expltools/pull/14 and https://github.com/Witiko/expltools/pull/16.