### PR TITLE
Use a less naïve parser of TeX comments to improve the detection of issues W100 and E102

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
 - Correctly pluralize "1 file" on the first line of command-line output. (#14)
 
+- Use a less naïve parser of TeX comments to improve the detection of issues
+  W100 and E102. (reported by @FrankMittelbach in #8, fixed in #16)
+
 #### Documentation
 
 - Normalize the behavior and documentation of functions `get_*()` across files

--- a/explcheck/src/explcheck-preprocessing-comments.lua
+++ b/explcheck/src/explcheck-preprocessing-comments.lua
@@ -20,7 +20,6 @@ local newline = (
   + P("\r")
 )
 local linechar = any - newline
-local line = linechar^0 * newline
 local blank_line = optional_spaces * newline
 
 -- Define intermediate parsers.

--- a/explcheck/src/explcheck-preprocessing-comments.lua
+++ b/explcheck/src/explcheck-preprocessing-comments.lua
@@ -1,0 +1,109 @@
+-- The TeX comment removal part for the preprocessing step of static analysis.
+
+local lpeg = require("lpeg")
+local P, S, Cp, Ct = lpeg.P, lpeg.S, lpeg.Cp, lpeg.Ct
+
+-- Define base parsers.
+---- Generic
+local any = P(1)
+
+---- Tokens
+local percent_sign = P("%")
+local backslash = P([[\]])
+
+---- Spacing
+local spacechar = S("\t ")
+local optional_spaces = spacechar^0
+local newline = (
+  P("\n")
+  + P("\r\n")
+  + P("\r")
+)
+local linechar = any - newline
+local line = linechar^0 * newline
+local blank_line = optional_spaces * newline
+
+-- Define intermediate parsers.
+local commented_line_letter = (
+  linechar
+  + newline
+  - backslash
+  - percent_sign
+)
+local commented_line = (
+  (
+    (
+      commented_line_letter
+      - newline
+    )^1  -- initial state
+    + (
+      backslash  -- even backslash
+      * (
+        backslash
+        + #newline
+      )
+    )^1
+    + (
+      backslash
+      * (
+        percent_sign
+        + commented_line_letter
+      )
+    )
+  )^0
+  * (
+    #percent_sign
+    * Cp()
+    * (
+      (
+        percent_sign  -- comment
+        * linechar^0
+        * Cp()
+        * newline
+        * #blank_line  -- blank line
+      )
+      + percent_sign  -- comment
+      * linechar^0
+      * Cp()
+      * newline
+      * optional_spaces  -- leading spaces
+    )
+    + newline
+  )
+)
+
+-- Strip TeX comments from a text. Besides the transformed text, also return
+-- a function that maps positions in the transformed text back to the original
+-- text.
+local function strip_comments(text)
+  local transformed_index = 0
+  local numbers_of_bytes_removed = {}
+  local transformed_text_table = {}
+  for index, text_position in ipairs(lpeg.match(Ct(commented_line^1), text)) do
+    local span_size = text_position - transformed_index - 1
+    if span_size > 0 then
+      if index % 2 == 1 then  -- chunk of text
+        table.insert(transformed_text_table, text:sub(transformed_index + 1, text_position - 1))
+      else  -- comment
+        table.insert(numbers_of_bytes_removed, {transformed_index, span_size})
+      end
+      transformed_index = transformed_index + span_size
+    end
+  end
+  table.insert(transformed_text_table, text:sub(transformed_index + 1, -1))
+  local transformed_text = table.concat(transformed_text_table, "")
+  local function map_back(index)
+    for _, where_and_number_of_bytes_removed in ipairs(numbers_of_bytes_removed) do
+      local where, number_of_bytes_removed = table.unpack(where_and_number_of_bytes_removed)
+      if index > where then
+        index = index + number_of_bytes_removed
+      else
+        break
+      end
+    end
+    return index
+  end
+  return transformed_text, map_back
+end
+
+return strip_comments

--- a/explcheck/src/explcheck-preprocessing.lua
+++ b/explcheck/src/explcheck-preprocessing.lua
@@ -15,7 +15,6 @@ local fail = P(false)
 ---- Tokens
 local lbrace = P("{")
 local rbrace = P("}")
-local percent_sign = P("%")
 local backslash = P([[\]])
 local letter = R("AZ","az")
 local underscore = P("_")

--- a/explcheck/src/explcheck-preprocessing.lua
+++ b/explcheck/src/explcheck-preprocessing.lua
@@ -1,6 +1,7 @@
 -- The preprocessing step of static analysis determines which parts of the input files contain expl3 code.
 
 local config = require("explcheck-config")
+local strip_comments = require("explcheck-preprocessing-comments")
 
 local lpeg = require("lpeg")
 local Cp, P, R, S, V = lpeg.Cp, lpeg.P, lpeg.R, lpeg.S, lpeg.V
@@ -39,18 +40,9 @@ local optional_spaces_and_newline = (
 
 -- Define intermediate parsers.
 ---- Parts of TeX syntax
-local comment = (
-  percent_sign
-  * linechar^0
-  * newline
-  * optional_spaces
-)
 local argument = (
   lbrace
-  * (
-    comment
-    + (any - rbrace)
-  )^0
+  * (any - rbrace)^0
   * rbrace
 )
 
@@ -91,16 +83,12 @@ local provides = (
       + P("File")
     )
   * optional_spaces_and_newline
-  * comment^0
   * argument
   * optional_spaces_and_newline
-  * comment^0
   * argument
   * optional_spaces_and_newline
-  * comment^0
   * argument
   * optional_spaces_and_newline
-  * comment^0
   * argument
 )
 local expl_syntax_on = P([[\ExplSyntaxOn]])
@@ -143,15 +131,20 @@ local function preprocessing(issues, content, options)
   )
   lpeg.match(line_numbers_grammar, content)
 
+  -- Strip TeX comments before further analysis.
+  local transformed_content, map_back = strip_comments(content)
+
   -- Determine which parts of the input files contain expl3 code.
   local expl_ranges = {}
 
   local function capture_range(range_start, range_end)
+    range_start, range_end = map_back(range_start), map_back(range_end)
     table.insert(expl_ranges, {range_start, range_end + 1})
   end
 
   local function unexpected_pattern(pattern, code, message, test)
     return Cp() * pattern * Cp() / function(range_start, range_end)
+      range_start, range_end = map_back(range_start), map_back(range_end)
       if test == nil or test() then
         issues:add(code, message, range_start, range_end + 1)
       end
@@ -221,7 +214,7 @@ local function preprocessing(issues, content, options)
     Opener = Opener,
     Closer = Closer,
   }
-  lpeg.match(analysis_grammar, content)
+  lpeg.match(analysis_grammar, transformed_content)
 
   -- If no parts were detected, assume that the whole input file is in expl3.
   if(#expl_ranges == 0 and #content > 0) then

--- a/explcheck/testfiles/e102-01.lua
+++ b/explcheck/testfiles/e102-01.lua
@@ -1,0 +1,32 @@
+local new_issues = require("explcheck-issues")
+local format = require("explcheck-format")
+local preprocessing = require("explcheck-preprocessing")
+
+local filename = "e102-01.tex"
+
+local file = assert(io.open(filename, "r"))
+local content = assert(file:read("*a"))
+assert(file:close())
+local issues = new_issues()
+
+local line_starting_byte_numbers = preprocessing(issues, content)
+
+assert(#issues.errors == 3)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {3, 5, 7}
+for index, err in ipairs(issues.sort(issues.errors)) do
+  assert(err[1] == "e102")
+  assert(err[2] == "expl3 control sequences in non-expl3 parts")
+  local range_start_byte_number, range_end_byte_number = table.unpack(err[3])
+  local range_start_line_number = format.convert_byte_to_line_and_column(
+    line_starting_byte_numbers,
+    range_start_byte_number
+  )
+  local range_end_line_number = format.convert_byte_to_line_and_column(
+    line_starting_byte_numbers,
+    range_end_byte_number - 1
+  )
+  assert(range_start_line_number == expected_line_numbers[index])
+  assert(range_end_line_number == expected_line_numbers[index])
+end

--- a/explcheck/testfiles/e102-01.tex
+++ b/explcheck/testfiles/e102-01.tex
@@ -1,0 +1,7 @@
+\ProvidesExplFile{example.tex}{2024-12-13}{1.0.0}{An example file}
+\ExplSyntaxOff
+foo \tl_show:n { bar }  % error on this line
+foo % \tl_show:n { bar }
+foo \% \tl_show:n { bar }  % error on this line
+foo \\% \tl_show:n { bar }
+foo \\\% \tl_show:n { bar }  % error on this line

--- a/explcheck/testfiles/w100-03.lua
+++ b/explcheck/testfiles/w100-03.lua
@@ -1,0 +1,14 @@
+local new_issues = require("explcheck-issues")
+local preprocessing = require("explcheck-preprocessing")
+
+local filename = "w100-03.tex"
+
+local file = assert(io.open(filename, "r"))
+local content = assert(file:read("*a"))
+assert(file:close())
+local issues = new_issues()
+
+preprocessing(issues, content)
+
+assert(#issues.errors == 0)
+assert(#issues.warnings == 0)

--- a/explcheck/testfiles/w100-03.tex
+++ b/explcheck/testfiles/w100-03.tex
@@ -1,0 +1,1 @@
+\ProvidesExplFile {examp \% le.tex} {2024-04-09} {1.0.0} {An example file}


### PR DESCRIPTION
This PR makes the following changes:
- [x] Add tests for a less naïve parsing of TeX comments.
- [x] Implement less naïve parsing of TeX comments.

For the less naïve parsing of TeX comments, we can use the regular language of TeX comments described in Section 2.2 and Figure 4 of the TUGboat article [_Markdown 2.10.0: LaTeX themes & snippets, two flavors of comments, and LuaMetaTeX_][1] as well as in Figure 6 of [the technical documentation of the Markdown package for TeX][2].

 [1]: https://doi.org/10.47397/tb/42-2/tb131novotny-markdown
 [2]: https://github.com/Witiko/markdown/releases/download/latest/markdown.pdf

This PR closes ticket #8, together with pull requests #14 and #15.