### PR TITLE
Support Vim's quickfix errorformat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,18 @@
 
 ### explcheck v0.7.0-dev
 
+#### Development
+
+- Add command-line option `--error-format` and Lua option `error_format` for
+  specifying Vim's quickfix errorformat used for the machine-readable output
+  when the command-line option `--porcelain` is enabled.
+  (discussed with @koppor in koppor/errorformat-to-html#2, added in #40)
+
+#### Fixes
+
+- In machine-readable output, report the line and column number 1 for file-wide
+  issues. (reported by @koppor in #39, fixed in #40)
+
 ## expltools 2025-01-20
 
 ### explcheck v0.6.1

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -124,7 +124,7 @@ local function main(pathnames, options)
     ::continue::
     num_warnings = num_warnings + #issues.warnings
     num_errors = num_errors + #issues.errors
-    format.print_results(pathname, issues, line_starting_byte_numbers, pathname_number == #pathnames, options.porcelain)
+    format.print_results(pathname, issues, line_starting_byte_numbers, pathname_number == #pathnames, options)
   end
 
   -- Print a summary.
@@ -147,6 +147,8 @@ local function print_usage()
   local max_line_length = tostring(config.max_line_length)
   print(
     "Options:\n\n"
+    .. "\t--error-format=FORMAT      The Vim's quickfix errorformat used for the output with --porcelain enabled.\n"
+    .. "\t                           The default format is FORMAT=\"" .. config.error_format .. "\".\n\n"
     .. "\t--expect-expl3-everywhere  Expect that the whole files are in expl3, ignoring \\ExplSyntaxOn and Off.\n"
     .. "\t                           This prevents the error E102 (expl3 material in non-expl3 parts).\n\n"
     .. "\t--ignored-issues=ISSUES    A comma-list of warning and error identifiers that should not be reported.\n\n"
@@ -183,6 +185,8 @@ else
     elseif argument == "--version" or argument == "-v" then
       print_version()
       os.exit(0)
+    elseif argument:sub(1, 15) == "--error-format=" then
+      options.error_format = argument:sub(16)
     elseif argument == "--expect-expl3-everywhere" then
       options.expect_expl3_everywhere = true
     elseif argument:sub(1, 17) == "--ignored-issues=" then

--- a/explcheck/src/explcheck-config.lua
+++ b/explcheck/src/explcheck-config.lua
@@ -4,11 +4,12 @@ local toml = require("explcheck-toml")
 
 -- The default options
 local default_options = {
+  error_format = '%f:%l:%c: %t%n %m',
   expect_expl3_everywhere = false,
+  ignored_issues = {},
   max_line_length = 80,
   porcelain = false,
   warnings_are_errors = false,
-  ignored_issues = {},
 }
 
 -- Read a TOML file with a user-defined configuration.


### PR DESCRIPTION
This PR makes the following changes:
- Add command-line option `--error-format` and Lua option `error_format` for specifying Vim's quickfix errorformat used for the machine-readable output when the command-line option `--porcelain` is enabled.
- In machine-readable output, report the line and column number 1 for file-wide issues.

Closes #39.