### PR TITLE
Fix 204 vs. 206

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ jobs:
 
 You may configure the tool using command-line options.
 
-For example, the following command-line options would increase the maximum line length before the warning S103 (Line too long) is produced from 80 to 120 characters and also disable the warnings W100 (No standard delimiters) and S206 (Missing stylistic whitespaces).
+For example, the following command-line options would increase the maximum line length before the warning S103 (Line too long) is produced from 80 to 120 characters and also disable the warnings W100 (No standard delimiters) and S204 (Missing stylistic whitespaces).
 
 ``` sh
-$ explcheck --max-line-length=120 --ignored-issues=w100,s206 *.tex
+$ explcheck --max-line-length=120 --ignored-issues=w100,s204 *.tex
 ```
 
 Use the command `explcheck --help` to list the available options.
@@ -102,7 +102,7 @@ For example, here is a configuration file that applies the same configuration as
 ``` toml
 [options]
 max_line_length = 120
-ignored_issues = ["w100", "s206"]
+ignored_issues = ["w100", "s204"]
 ```
 
 You may also configure the tool from within your Lua code.
@@ -112,7 +112,7 @@ For example, here is how you would apply the same configuration in the Lua examp
 local options = { max_line_length = 120 }
 
 issues:ignore("w100")
-issues:ignore("s206")
+issues:ignore("s204")
 
 local _, expl_ranges = preprocessing(issues, content, options)
 lexical_analysis(issues, content, expl_ranges, options)
@@ -122,7 +122,7 @@ Command-line options, configuration files, and Lua code allow you to ignore cert
 To ignore them in just some of your expl3 code, you may use TeX comments.
 
 For example, a comment `% noqa` will ignore any issues on the current line.
-As another example, a comment `% noqa: w100, s206` will ignore the file-wide warning W100 and also the warning S206 on the current line.
+As another example, a comment `% noqa: w100, s204` will ignore the file-wide warning W100 and also the warning S204 on the current line.
 
 ## Notes to distributors
 


### PR DESCRIPTION
The tool outputs as of today

   s204 missing stylistic whitespaces

I updated the readmy accordingly.

I assume that S206 is something different and the README.md intents to refer to "Missing stylistic whitespaces"