### PR TITLE
Exclude comments from maximum line length checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,11 @@
 - In machine-readable output, report the line and column number 1 for file-wide
   issues. (reported by @koppor in #39, fixed in #40)
 
+- Exclude comments from maximum line length checks. (reported by @muzimuzhi in
+  #27, fixed in #43)
+
+  This includes spaces before the comments.
+
 #### Artwork
 
 - Add artwork by https://fiverr.com/quickcartoon to directory `artwork/`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,13 @@
 
 #### Development
 
-- Add command-line option `--error-format` and Lua option `error_format` for
-  specifying Vim's quickfix errorformat used for the machine-readable output
-  when the command-line option `--porcelain` is enabled.
-  (discussed with @koppor in koppor/errorformat-to-html#2, added in #40 and
-  5034639)
+- Add command-line option `--error-format` and Lua option `error_format`.
+  (discussed with @koppor in koppor/errorformat-to-html#2, added in #40,
+  5034639, and #43)
+
+  This allows users to specify Vim's quickfix errorformat used for the
+  machine-readable output when the command-line option `--porcelain` or the Lua
+  option `porcelain` is enabled.
 
 #### Fixes
 

--- a/explcheck/src/explcheck-format.lua
+++ b/explcheck/src/explcheck-format.lua
@@ -159,8 +159,8 @@ local function print_results(pathname, issues, line_starting_byte_numbers, is_la
         local end_line_number, end_column_number = 1, 1
         if range ~= nil then
           start_line_number, start_column_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, range[1])
-          end_line_number, end_column_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, range[2])
-          end_column_number = end_column_number - 1
+          end_line_number, end_column_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, range[2] - 1)
+          end_column_number = end_column_number
         end
         local position = ":" .. tostring(start_line_number) .. ":" .. tostring(start_column_number) .. ":"
         local max_line_length = 88

--- a/explcheck/src/explcheck-parsers.lua
+++ b/explcheck/src/explcheck-parsers.lua
@@ -76,7 +76,7 @@ for catcode, parser in pairs(expl3_catcodes) do
 end
 
 ---- Syntax recognized by TeX's input and token processors
-local optional_spaces = space^0
+local optional_spaces = expl3_catcodes[9]^0
 local optional_spaces_and_newline = (
   optional_spaces
   * (
@@ -99,7 +99,7 @@ local tex_line = (
   (
     (
       linechar
-      - (space * #blank_or_empty_last_line)
+      - (expl3_catcodes[9] * #blank_or_empty_last_line)
     )^1
     * (
       blank_or_empty_last_line / ""
@@ -108,7 +108,7 @@ local tex_line = (
   + (
     (
       linechar
-      - (space * #blank_line)
+      - (expl3_catcodes[9] * #blank_line)
     )^0
     * (
       blank_line / ""
@@ -256,6 +256,7 @@ local commented_line_letter = (
   + newline
   - expl3_catcodes[0]
   - expl3_catcodes[14]
+  - expl3_catcodes[9]
 )
 local commented_line = (
   (
@@ -277,19 +278,31 @@ local commented_line = (
         + commented_line_letter
       )
     )
+    + (
+      #(
+        optional_spaces
+        * -expl3_catcodes[14]
+      )
+      * expl3_catcodes[9]
+    )
   )^0
   * (
-    #expl3_catcodes[14]
+    #(
+      optional_spaces
+      * expl3_catcodes[14]
+    )
     * Cp()
     * (
       (
-        expl3_catcodes[14]  -- comment
+        optional_spaces
+        * expl3_catcodes[14]  -- comment
         * linechar^0
         * Cp()
         * newline
         * #blank_line  -- blank line
       )
-      + expl3_catcodes[14]  -- comment
+      + optional_spaces
+      * expl3_catcodes[14]  -- comment
       * linechar^0
       * Cp()
       * newline

--- a/explcheck/src/explcheck-preprocessing.lua
+++ b/explcheck/src/explcheck-preprocessing.lua
@@ -9,6 +9,25 @@ local Cp, Ct, P, V = lpeg.Cp, lpeg.Ct, lpeg.P, lpeg.V
 -- Preprocess the content and register any issues.
 local function preprocessing(issues, content, options)
 
+  -- Determine the bytes where lines begin.
+  local line_starting_byte_numbers = {}
+
+  local function record_line(line_start)
+    table.insert(line_starting_byte_numbers, line_start)
+  end
+
+  local line_numbers_grammar = (
+    Cp() / record_line
+    * (
+      (
+        parsers.linechar^0
+        * parsers.newline
+        * Cp()
+      ) / record_line
+    )^0
+  )
+  lpeg.match(line_numbers_grammar, content)
+
   -- Strip TeX comments before further analysis.
   local function strip_comments()
     local transformed_index = 0
@@ -70,32 +89,19 @@ local function preprocessing(issues, content, options)
 
   local transformed_content, map_back = strip_comments()
 
-  -- Determine the bytes where lines begin.
-  local line_starting_byte_numbers = {}
-
-  local function record_line(line_start)
-    line_start = map_back(line_start)
-    table.insert(line_starting_byte_numbers, line_start)
-  end
-
+  -- Check for overlong lines.
   local function line_too_long(range_start, range_end)
-    range_start, range_end = map_back(range_start), map_back(range_end)
+    range_start, range_end = map_back(range_start), map_back(range_end - 1)
     issues:add('s103', 'line too long', range_start, range_end + 1)
   end
 
   local line_numbers_grammar = (
-    Cp() / record_line
-    * (
-      (
-        (
-          Cp() * parsers.linechar^(utils.get_option(options, 'max_line_length') + 1) * Cp() / line_too_long
-          + parsers.linechar^0
-        )
-        * parsers.newline
-        * Cp()
-      ) / record_line
-    )^0
-  )
+    (
+      Cp() * parsers.linechar^(utils.get_option(options, 'max_line_length') + 1) * Cp() / line_too_long
+      + parsers.linechar^0
+    )
+    * parsers.newline
+  )^0
   lpeg.match(line_numbers_grammar, transformed_content)
 
   -- Determine which parts of the input files contain expl3 code.

--- a/explcheck/src/explcheck-preprocessing.lua
+++ b/explcheck/src/explcheck-preprocessing.lua
@@ -95,14 +95,14 @@ local function preprocessing(issues, content, options)
     issues:add('s103', 'line too long', range_start, range_end + 1)
   end
 
-  local line_numbers_grammar = (
+  local overline_lines_grammar = (
     (
       Cp() * parsers.linechar^(utils.get_option(options, 'max_line_length') + 1) * Cp() / line_too_long
       + parsers.linechar^0
     )
     * parsers.newline
   )^0
-  lpeg.match(line_numbers_grammar, transformed_content)
+  lpeg.match(overline_lines_grammar, transformed_content)
 
   -- Determine which parts of the input files contain expl3 code.
   local expl_ranges = {}

--- a/explcheck/testfiles/s103.tex
+++ b/explcheck/testfiles/s103.tex
@@ -1,2 +1,3 @@
 This line is not very long, because it is 80 characters long, not 81 characters.
-This line is very long, because it is 81 characters long.  % warning on this line
+This line is overly long, because it is 81 characters long excluding the comment.  % warning on this line
+This line is not very long, because it is 80 characters long, comments excluded.  % no warning on this line


### PR DESCRIPTION
This PR makes the following changes:

- Exclude comments from maximum line length checks. This includes spaces before the comments.

This PR also makes the following changes:

- Correctly determine end column number for errorformat items `%e` and `%k`.

Closes #27.