### PR TITLE
Always accept both lower- and upper-case issue identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,12 @@
 - In machine-readable output, report the line and column number 1 for file-wide
   issues. (reported by @koppor in #39, fixed in #40)
 
+- Always accept both lower- and upper-case issue identifiers. (reported by
+  @muzimuzhi in #26, fixed in #44)
+
+  This includes Lua options and configuration files, in addition to
+  command-line options and inline TeX comments.
+
 #### Artwork
 
 - Add artwork by https://fiverr.com/quickcartoon to directory `artwork/`.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You may configure the tool using command-line options.
 For example, the following command-line options would increase the maximum line length before the warning S103 (Line too long) is produced from 80 to 120 characters and also disable the warnings W100 (No standard delimiters) and S204 (Missing stylistic whitespaces).
 
 ``` sh
-$ explcheck --max-line-length=120 --ignored-issues=w100,s204 *.tex
+$ explcheck --max-line-length=120 --ignored-issues=w100,S204 *.tex
 ```
 
 Use the command `explcheck --help` to list the available options.
@@ -102,7 +102,7 @@ For example, here is a configuration file that applies the same configuration as
 ``` toml
 [options]
 max_line_length = 120
-ignored_issues = ["w100", "s204"]
+ignored_issues = ["w100", "S204"]
 ```
 
 You may also configure the tool from within your Lua code.
@@ -112,7 +112,7 @@ For example, here is how you would apply the same configuration in the Lua examp
 local options = { max_line_length = 120 }
 
 issues:ignore("w100")
-issues:ignore("s204")
+issues:ignore("S204")
 
 local _, expl_ranges = preprocessing(issues, content, options)
 lexical_analysis(issues, content, expl_ranges, options)
@@ -122,7 +122,7 @@ Command-line options, configuration files, and Lua code allow you to ignore cert
 To ignore them in just some of your expl3 code, you may use TeX comments.
 
 For example, a comment `% noqa` will ignore any issues on the current line.
-As another example, a comment `% noqa: w100, s204` will ignore the file-wide warning W100 and also the warning S204 on the current line.
+As another example, a comment `% noqa: w100, S204` will ignore the file-wide warning W100 and also the warning S204 on the current line.
 
 ## Notes to distributors
 

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -192,7 +192,7 @@ else
     elseif argument:sub(1, 17) == "--ignored-issues=" then
       options.ignored_issues = {}
       for issue_identifier in argument:sub(18):gmatch('[^,]+') do
-        table.insert(options.ignored_issues, issue_identifier:lower())
+        table.insert(options.ignored_issues, issue_identifier)
       end
     elseif argument:sub(1, 18) == "--max-line-length=" then
       options.max_line_length = tonumber(argument:sub(19))

--- a/explcheck/src/explcheck-issues.lua
+++ b/explcheck/src/explcheck-issues.lua
@@ -12,8 +12,14 @@ function Issues.new(cls)
   return new_object
 end
 
+-- Normalize an issue identifier.
+function Issues:_normalize_identifier(identifier)
+  return identifier:lower()
+end
+
 -- Convert an issue identifier to either a table of warnings or a table of errors.
 function Issues:_get_issue_table(identifier)
+  identifier = self:_normalize_identifier(identifier)
   local prefix = identifier:sub(1, 1)
   if prefix == "s" or prefix == "w" then
     return self.warnings
@@ -26,6 +32,8 @@ end
 
 -- Add an issue to the table of issues.
 function Issues:add(identifier, message, range_start, range_end)
+  identifier = self:_normalize_identifier(identifier)
+
   -- Construct the issue.
   local range
   if range_start == nil then
@@ -49,6 +57,8 @@ end
 
 -- Prevent issues from being present in the table of issues.
 function Issues:ignore(identifier, range_start, range_end)
+  identifier = self:_normalize_identifier(identifier)
+
   -- Determine which issues should be ignored.
   local function match_issue_range(issue_range)
     local issue_range_start, issue_range_end = table.unpack(issue_range)

--- a/explcheck/src/explcheck-issues.lua
+++ b/explcheck/src/explcheck-issues.lua
@@ -13,13 +13,13 @@ function Issues.new(cls)
 end
 
 -- Normalize an issue identifier.
-function Issues:_normalize_identifier(identifier)
+function Issues._normalize_identifier(identifier)
   return identifier:lower()
 end
 
 -- Convert an issue identifier to either a table of warnings or a table of errors.
 function Issues:_get_issue_table(identifier)
-  identifier = self:_normalize_identifier(identifier)
+  identifier = self._normalize_identifier(identifier)
   local prefix = identifier:sub(1, 1)
   if prefix == "s" or prefix == "w" then
     return self.warnings
@@ -32,7 +32,7 @@ end
 
 -- Add an issue to the table of issues.
 function Issues:add(identifier, message, range_start, range_end)
-  identifier = self:_normalize_identifier(identifier)
+  identifier = self._normalize_identifier(identifier)
 
   -- Construct the issue.
   local range
@@ -57,7 +57,7 @@ end
 
 -- Prevent issues from being present in the table of issues.
 function Issues:ignore(identifier, range_start, range_end)
-  identifier = self:_normalize_identifier(identifier)
+  identifier = self._normalize_identifier(identifier)
 
   -- Determine which issues should be ignored.
   local function match_issue_range(issue_range)

--- a/explcheck/src/explcheck-parsers.lua
+++ b/explcheck/src/explcheck-parsers.lua
@@ -302,9 +302,6 @@ local commented_line = (
 -- Explcheck issues
 local issue_code = (
   S("EeSsTtWw")
-  / function(prefix)
-    return prefix:lower()
-  end
   * decimal_digit
   * decimal_digit
   * decimal_digit


### PR DESCRIPTION
This PR makes the following changes:

- Always accept both lower- and upper-case issue identifiers. This includes Lua options and configuration files, in addition to command-line options and inline TeX comments.

Closes #26.