### PR TITLE
Exclude "weird" (`:w`) argument specifiers from warning W200

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@
 - In machine-readable output, report the line and column number 1 for file-wide
   issues. (reported by @koppor in #39, fixed in #40)
 
+- Exclude "weird" argument specifiers (`:w`) from warning W200. (reported by
+  @muzimuzhi in #25, fixed in #45)
+
 #### Artwork
 
 - Add artwork by https://fiverr.com/quickcartoon to directory `artwork/`.

--- a/explcheck/doc/warnings-and-errors-02-lexical-analysis.md
+++ b/explcheck/doc/warnings-and-errors-02-lexical-analysis.md
@@ -1,8 +1,8 @@
 # Lexical analysis
 In the lexical analysis step, the expl3 analysis tool converts the expl3 parts of the input files into a list of `\TeX`{=tex} tokens.
 
-## “Weird” and “Do not use” argument specifiers {.w label=w200}
-Some control sequence tokens correspond to functions with `w` (weird) or `D` (do not use) argument specifiers.
+## “Do not use” argument specifiers {.w label=w200}
+Some control sequence tokens correspond to functions with `D` (do not use) argument specifiers.
 
  /w200.tex
 

--- a/explcheck/src/explcheck-lexical-analysis.lua
+++ b/explcheck/src/explcheck-lexical-analysis.lua
@@ -225,8 +225,8 @@ local function lexical_analysis(issues, all_content, expl_ranges, options)  -- l
         local csname = payload
         local _, _, argument_specifiers = csname:find(":(.*)")
         if argument_specifiers ~= nil then
-          if lpeg.match(parsers.weird_argument_specifiers, argument_specifiers) then
-            issues:add('w200', '"weird" and "do not use" argument specifiers', range_start, range_end)
+          if lpeg.match(parsers.do_not_use_argument_specifiers, argument_specifiers) then
+            issues:add('w200', '"do not use" argument specifiers', range_start, range_end)
           end
           if lpeg.match(parsers.argument_specifiers, argument_specifiers) == nil then
             issues:add('e201', 'unknown argument specifiers', range_start, range_end)

--- a/explcheck/src/explcheck-parsers.lua
+++ b/explcheck/src/explcheck-parsers.lua
@@ -157,15 +157,20 @@ local argument = (
   * expl3_catcodes[2]
 )
 
-local weird_argument_specifier = S("wD")
-local argument_specifier = S("NncVvoxefTFp") + weird_argument_specifier
+local weird_argument_specifier = S("w")
+local do_not_use_argument_specifier = S("D")
+local argument_specifier = (
+  S("NncVvoxefTFp")
+  + weird_argument_specifier
+  + do_not_use_argument_specifier
+)
 local argument_specifiers = argument_specifier^0 * eof
-local weird_argument_specifiers = (
+local do_not_use_argument_specifiers = (
   (
     argument_specifier
-    - weird_argument_specifier
+    - do_not_use_argument_specifier
   )^0
-  * weird_argument_specifier
+  * do_not_use_argument_specifier
 )
 
 ---- Function, variable, and constant names
@@ -400,6 +405,7 @@ return {
   commented_line = commented_line,
   decimal_digit = decimal_digit,
   determine_expl3_catcode = determine_expl3_catcode,
+  do_not_use_argument_specifiers = do_not_use_argument_specifiers,
   double_superscript_convention = double_superscript_convention,
   eof = eof,
   fail = fail,
@@ -420,5 +426,4 @@ return {
   non_expl3_csname = non_expl3_csname,
   provides = provides,
   tex_lines = tex_lines,
-  weird_argument_specifiers = weird_argument_specifiers,
 }

--- a/explcheck/testfiles/w200.lua
+++ b/explcheck/testfiles/w200.lua
@@ -16,12 +16,12 @@ local line_starting_byte_numbers, expl_ranges = preprocessing(issues, content, o
 lexical_analysis(issues, content, expl_ranges, options)
 
 assert(#issues.errors == 0)
-assert(#issues.warnings == 6)
+assert(#issues.warnings == 4)
 
-local expected_line_numbers = {2, 3, 5, 6, 7, 8}
+local expected_line_numbers = {1, 2, 3, 4}
 for index, warning in ipairs(issues.sort(issues.warnings)) do
   assert(warning[1] == "w200")
-  assert(warning[2] == '"weird" and "do not use" argument specifiers')
+  assert(warning[2] == '"do not use" argument specifiers')
   local range_start_byte_number, range_end_byte_number = table.unpack(warning[3])
   local range_start_line_number = utils.convert_byte_to_line_and_column(
     line_starting_byte_numbers,

--- a/explcheck/testfiles/w200.tex
+++ b/explcheck/testfiles/w200.tex
@@ -1,8 +1,4 @@
-\cs_new:Npn
-  \show_until_if:w  % warning on this line
-  #1 \if^^zw  % warning on this line
-  { \tl_show:n {#1} }
-\show_until_if:^^7  % warning on this line
-  \tex_if:D  % warning on this line
-  \if_charcode:^^77  % warning on this line
-  \if^^3aw  % warning on this line
+\tex_space:D  % warning on this line
+\tex_italiccor^^3aD  % warning on this line
+\tex_hyphen^^zD  % warning on this line
+\tex_let:^^44  % warning on this line


### PR DESCRIPTION
This PR makes the following changes:

- Exclude "weird" (`:w`) argument specifiers from warning W200.

Closes #25.