### PR TITLE
Add SPDX Identifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,10 @@
   Use the command-line option `--expl3-detection-strategy=always` or the
   corresponding Lua option instead.
 
+#### Documentation
+
+- Add SPDX license identifier to `README.md`. (fixed by @koppor in #50)
+
 #### Housekeeping
 
 - Make off-by-one errors less likely when working with byte ranges.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,6 @@ The file `explcheck.lua` should be installed in the TDS directory `scripts/explt
 
 This material is dual-licensed under GNU GPL 2.0 or later and LPPL 1.3c or later.
 
-```yaml
+``` yaml
 SPDX-License-Identifier: GPL-2.0-or-later OR LPPL-1.3c
 ```

--- a/README.md
+++ b/README.md
@@ -140,3 +140,7 @@ The file `explcheck.lua` should be installed in the TDS directory `scripts/explt
 ## License
 
 This material is dual-licensed under GNU GPL 2.0 or later and LPPL 1.3c or later.
+
+```yaml
+SPDX-License-Identifier: GPL-2.0-or-later OR LPPL-1.3c
+```


### PR DESCRIPTION
According to https://softwareengineering.stackexchange.com/a/371435/52607 (self cite ^^), it is a good practise to use SPDX License Identifiers for dual licensed work. To make clear, which licenses apply.