### PR TITLE
Assert that `commented_lines` always matches the whole file content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
   issues. (reported by @koppor in #39, fixed in #40)
 
 - Exclude comments from maximum line length checks. (reported by @muzimuzhi in
-  #27, fixed in #43 and #58)
+  #27, fixed in #43, #58, and #59)
 
   This includes spaces before the comments.
 

--- a/explcheck/src/explcheck-parsers.lua
+++ b/explcheck/src/explcheck-parsers.lua
@@ -263,17 +263,17 @@ local commented_line_letter = (
   - expl3_catcodes[9]
   - expl3_catcodes[14]
 )
-local commented_line = (
-  (
+local function commented_line(closer)
+  return (
     (
       commented_line_letter
-      - newline
+      - closer
     )^1  -- initial state
     + (
       expl3_catcodes[0]  -- even backslash
       * (
         expl3_catcodes[0]
-        + #newline
+        + #closer
       )
     )^1
     + (
@@ -304,19 +304,22 @@ local commented_line = (
         * expl3_catcodes[14]  -- comment
         * linechar^0
         * Cp()
-        * newline
+        * closer
         * (
           #blank_line  -- blank line
           + expl3_catcodes[9]^0  -- leading spaces
         )
       )
     )
-    + newline
+    + closer
   )
-)
+end
+
 local commented_lines = Ct(
-  commented_line^0
+  commented_line(newline)^0
+  * commented_line(eof)
   * eof
+  + eof
 )
 
 -- Explcheck issues

--- a/explcheck/src/explcheck-parsers.lua
+++ b/explcheck/src/explcheck-parsers.lua
@@ -314,6 +314,10 @@ local commented_line = (
     + newline
   )
 )
+local commented_lines = Ct(
+  commented_line^0
+  * eof
+)
 
 -- Explcheck issues
 local issue_code = (
@@ -412,7 +416,7 @@ local expl3_quark_or_scan_mark_csname = S("qs") * P("_")
 return {
   any = any,
   argument_specifiers = argument_specifiers,
-  commented_line = commented_line,
+  commented_lines = commented_lines,
   decimal_digit = decimal_digit,
   determine_expl3_catcode = determine_expl3_catcode,
   do_not_use_argument_specifiers = do_not_use_argument_specifiers,

--- a/explcheck/src/explcheck-preprocessing.lua
+++ b/explcheck/src/explcheck-preprocessing.lua
@@ -5,7 +5,7 @@ local utils = require("explcheck-utils")
 local new_range = require("explcheck-ranges")
 
 local lpeg = require("lpeg")
-local Cp, Ct, P, V = lpeg.Cp, lpeg.Ct, lpeg.P, lpeg.V
+local Cp, P, V = lpeg.Cp, lpeg.P, lpeg.V
 
 -- Preprocess the content and register any issues.
 local function preprocessing(issues, content, options)

--- a/explcheck/src/explcheck-preprocessing.lua
+++ b/explcheck/src/explcheck-preprocessing.lua
@@ -34,7 +34,7 @@ local function preprocessing(issues, content, options)
     local transformed_index = 0
     local numbers_of_bytes_removed = {}
     local transformed_text_table = {}
-    for index, text_position in ipairs(lpeg.match(Ct(parsers.commented_line^1), content) or {}) do
+    for index, text_position in ipairs(lpeg.match(parsers.commented_lines, content)) do
       local span_size = text_position - transformed_index - 1
       if span_size > 0 then
         if index % 2 == 1 then  -- chunk of text


### PR DESCRIPTION
This PR makes the following changes:
- Assert that `commented_lines` always matches the whole file content.
- Correctly parse comments on the last line of a file that doesn't end with a newline.

This should prevent future issues such as the one fixed in #58 from going unnoticed.