### PR TITLE
Stabilize the Lua API of processing steps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,17 @@
 
 ### explcheck v0.8.0
 
+#### Development
+
+- Stabilize the Lua API of processing steps. (#64)
+
+  All processing steps are now functions that accept the following arguments:
+  1. The filename of a processed file
+  2. The content of the processed file
+  3. A registry of issues with the processed file (write-only)
+  4. Intermediate analysis results (read-write)
+  5. Options (read-only, optional)
+
 ## expltools 2025-02-25
 
 ### explcheck v0.7.1

--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ end
 -- Process file "code.tex" and print warnings and errors.
 local filename = "code.tex"
 local issues = new_issues()
+local results = {}
 
 local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 
-local _, expl_ranges, is_latex = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, is_latex, options)
+preprocessing(filename, content, issues, results)
+lexical_analysis(filename, content, issues, results)
 
 print(
   "There were " .. #issues.warnings .. " warnings, "
@@ -120,8 +121,8 @@ local options = { max_line_length = 120 }
 issues:ignore("w100")
 issues:ignore("S204")
 
-local _, expl_ranges, is_latex = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, is_latex, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 ```
 
 Command-line options, configuration files, and Lua code allow you to ignore certain warnings and errors everywhere.

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -103,7 +103,8 @@ local function main(pathnames, options)
       ::continue::
       num_warnings = num_warnings + #issues.warnings
       num_errors = num_errors + #issues.errors
-      format.print_results(pathname, issues, line_starting_byte_numbers, pathname_number == #pathnames, options)
+      assert(results.line_starting_byte_numbers ~= nil)
+      format.print_results(pathname, issues, results.line_starting_byte_numbers, pathname_number == #pathnames, options)
     end, debug.traceback)
     if not is_ok then
       error("Failed to process " .. pathname .. ": " .. tostring(error_message), 0)

--- a/explcheck/src/explcheck-config.lua
+++ b/explcheck/src/explcheck-config.lua
@@ -32,13 +32,13 @@ local function get_option(key, options, pathname)
     if pathname ~= nil then
       -- If a pathname is provided and the current configuration specifies the option for this filename, use it.
       local filename = utils.get_basename(pathname)
-      if config["filename"] and config["filename"][filename] ~= nil and config["filename"][filename][key] ~= nil then
-        return config["filename"][filename][key]
+      if config.filename and config.filename[filename] ~= nil and config.filename[filename][key] ~= nil then
+        return config.filename[filename][key]
       end
       -- If a pathname is provided and the current configuration specifies the option for this package, use it.
       local package = utils.get_basename(utils.get_parent(pathname))
-      if config["package"] and config["package"][package] ~= nil and config["package"][package][key] ~= nil then
-        return config["package"][package][key]
+      if config.package and config.package[package] ~= nil and config.package[package][key] ~= nil then
+        return config.package[package][key]
       end
     end
     -- If the current configuration specifies the option in the defaults, use it.

--- a/explcheck/src/explcheck-lexical-analysis.lua
+++ b/explcheck/src/explcheck-lexical-analysis.lua
@@ -8,7 +8,7 @@ local parsers = require("explcheck-parsers")
 local lpeg = require("lpeg")
 
 -- Tokenize the content and register any issues.
-local function lexical_analysis(issues, pathname, all_content, expl_ranges, seems_like_latex_style_file, options)
+local function lexical_analysis(pathname, all_content, issues, results, options)
 
   -- Process bytes within a given range similarly to TeX's input processor (TeX's "eyes" [1]) and produce lines.
   --
@@ -66,7 +66,7 @@ local function lexical_analysis(issues, pathname, all_content, expl_ranges, seem
     -- Determine the category code of the at sign ("@").
     local make_at_letter = get_option("make_at_letter", options, pathname)
     if make_at_letter == "auto" then
-      make_at_letter = seems_like_latex_style_file
+      make_at_letter = results.seems_like_latex_style_file
     end
 
     for line_text, map_back in lines do
@@ -226,7 +226,7 @@ local function lexical_analysis(issues, pathname, all_content, expl_ranges, seem
 
   -- Tokenize the content.
   local all_tokens = {}
-  for _, range in ipairs(expl_ranges) do
+  for _, range in ipairs(results.expl_ranges) do
     local lines = (function()
       local co = coroutine.create(function()
         get_lines(range)
@@ -288,7 +288,8 @@ local function lexical_analysis(issues, pathname, all_content, expl_ranges, seem
     end
   end
 
-  return all_tokens
+  -- Store the intermediate results of the analysis.
+  results.tokens = all_tokens
 end
 
 return lexical_analysis

--- a/explcheck/src/explcheck-preprocessing.lua
+++ b/explcheck/src/explcheck-preprocessing.lua
@@ -9,7 +9,7 @@ local lpeg = require("lpeg")
 local Cp, P, V = lpeg.Cp, lpeg.P, lpeg.V
 
 -- Preprocess the content and register any issues.
-local function preprocessing(issues, pathname, content, options)
+local function preprocessing(pathname, content, issues, results, options)
 
   -- Determine the bytes where lines begin.
   local line_starting_byte_numbers = {}
@@ -231,7 +231,10 @@ local function preprocessing(issues, pathname, content, options)
     lpeg.match(overline_lines_grammar, transformed_content:sub(expl_range:start(), expl_range:stop()))
   end
 
-  return line_starting_byte_numbers, expl_ranges, seems_like_latex_style_file
+  -- Store the intermediate results of the analysis.
+  results.line_starting_byte_numbers = line_starting_byte_numbers
+  results.expl_ranges = expl_ranges
+  results.seems_like_latex_style_file = seems_like_latex_style_file
 end
 
 return preprocessing

--- a/explcheck/testfiles/e102-01.lua
+++ b/explcheck/testfiles/e102-01.lua
@@ -7,9 +7,10 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
-
+local results = {}
 local options = {expl3_detection_strategy = "always"}
-preprocessing(issues, filename, content, options)
+
+preprocessing(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/e102-02.lua
+++ b/explcheck/testfiles/e102-02.lua
@@ -7,8 +7,9 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 
-preprocessing(issues, filename, content)
+preprocessing(filename, content, issues, results)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/e102-03.lua
+++ b/explcheck/testfiles/e102-03.lua
@@ -8,8 +8,9 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 
-local line_starting_byte_numbers = preprocessing(issues, filename, content)
+preprocessing(filename, content, issues, results)
 
 assert(#issues.errors == 3)
 assert(#issues.warnings == 0)
@@ -19,8 +20,8 @@ for index, err in ipairs(issues.sort(issues.errors)) do
   assert(err[1] == "e102")
   assert(err[2] == "expl3 material in non-expl3 parts")
   local byte_range = err[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/e102.lua
+++ b/explcheck/testfiles/e102.lua
@@ -8,8 +8,9 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 
-local line_starting_byte_numbers = preprocessing(issues, filename, content)
+preprocessing(filename, content, issues, results)
 
 assert(#issues.errors == 2)
 assert(#issues.warnings == 0)
@@ -19,8 +20,8 @@ for index, err in ipairs(issues.sort(issues.errors)) do
   assert(err[1] == "e102")
   assert(err[2] == "expl3 material in non-expl3 parts")
   local byte_range = err[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/e104.lua
+++ b/explcheck/testfiles/e104.lua
@@ -8,8 +8,9 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 
-local line_starting_byte_numbers = preprocessing(issues, filename, content)
+preprocessing(filename, content, issues, results)
 
 assert(#issues.errors == 1)
 assert(#issues.warnings == 0)
@@ -20,7 +21,7 @@ local err = errors[1]
 assert(err[1] == "e104")
 assert(err[2] == [[multiple delimiters `\ProvidesExpl*` in a single file]])
 local byte_range = err[3]
-local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
 assert(start_line_number == 4)
 assert(end_line_number == 5)

--- a/explcheck/testfiles/e201.lua
+++ b/explcheck/testfiles/e201.lua
@@ -10,10 +10,11 @@ local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
 issues:ignore('s205')
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 1)
 assert(#issues.warnings == 0)
@@ -23,8 +24,8 @@ for index, err in ipairs(issues.sort(issues.errors)) do
   assert(err[1] == "e201")
   assert(err[2] == "unknown argument specifiers")
   local byte_range = err[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/e208.lua
+++ b/explcheck/testfiles/e208.lua
@@ -10,10 +10,11 @@ local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
 issues:ignore('s206')
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 1)
 assert(#issues.warnings == 0)
@@ -23,8 +24,8 @@ for index, err in ipairs(issues.sort(issues.errors)) do
   assert(err[1] == "e208")
   assert(err[2] == "too many closing braces")
   local byte_range = err[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/e209.lua
+++ b/explcheck/testfiles/e209.lua
@@ -10,10 +10,11 @@ local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
 issues:ignore('s204')
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 2)
 assert(#issues.warnings == 0)
@@ -23,8 +24,8 @@ for index, err in ipairs(issues.sort(issues.errors)) do
   assert(err[1] == "e209")
   assert(err[2] == "invalid characters")
   local byte_range = err[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/s103.lua
+++ b/explcheck/testfiles/s103.lua
@@ -8,9 +8,10 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "recall"}
 
-local line_starting_byte_numbers = preprocessing(issues, filename, content, options)
+preprocessing(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 2)
@@ -24,7 +25,7 @@ assert(warnings[1][3] == nil)  -- file-wide warning
 assert(warnings[2][1] == "s103")
 assert(warnings[2][2] == "line too long")
 local byte_range = warnings[2][3]
-local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
 assert(start_line_number == 2)
 assert(end_line_number == 2)

--- a/explcheck/testfiles/s204.lua
+++ b/explcheck/testfiles/s204.lua
@@ -9,10 +9,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 5)
@@ -22,8 +23,8 @@ for index, warning in ipairs(issues.sort(issues.warnings)) do
   assert(warning[1] == "s204")
   assert(warning[2] == "missing stylistic whitespaces")
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/s205-01.lua
+++ b/explcheck/testfiles/s205-01.lua
@@ -9,10 +9,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 1)
@@ -22,8 +23,8 @@ for index, warning in ipairs(issues.sort(issues.errors)) do
   assert(warning[1] == "s205")
   assert(warning[2] == "malformed function name")
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/s205-02.lua
+++ b/explcheck/testfiles/s205-02.lua
@@ -9,10 +9,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 1)
@@ -22,8 +23,8 @@ for index, warning in ipairs(issues.sort(issues.errors)) do
   assert(warning[1] == "s205")
   assert(warning[2] == "malformed function name")
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/s205-03.lua
+++ b/explcheck/testfiles/s205-03.lua
@@ -9,10 +9,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 1)
@@ -22,8 +23,8 @@ for index, warning in ipairs(issues.sort(issues.errors)) do
   assert(warning[1] == "s205")
   assert(warning[2] == "malformed function name")
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/s205-04.lua
+++ b/explcheck/testfiles/s205-04.lua
@@ -8,10 +8,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local _, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/s206-01.lua
+++ b/explcheck/testfiles/s206-01.lua
@@ -9,10 +9,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 3)
@@ -22,8 +23,8 @@ for index, warning in ipairs(issues.sort(issues.errors)) do
   assert(warning[1] == "s206")
   assert(warning[2] == "malformed variable or constant name")
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/s206-02.lua
+++ b/explcheck/testfiles/s206-02.lua
@@ -8,10 +8,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local _, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/s206-03.lua
+++ b/explcheck/testfiles/s206-03.lua
@@ -8,10 +8,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local _, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/s207-01.lua
+++ b/explcheck/testfiles/s207-01.lua
@@ -9,10 +9,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 1)
@@ -22,8 +23,8 @@ for index, warning in ipairs(issues.sort(issues.errors)) do
   assert(warning[1] == "s207")
   assert(warning[2] == "malformed quark or scan mark name")
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/s207-02.lua
+++ b/explcheck/testfiles/s207-02.lua
@@ -8,10 +8,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local _, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/s207-03.lua
+++ b/explcheck/testfiles/s207-03.lua
@@ -9,10 +9,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 1)
@@ -22,8 +23,8 @@ for index, warning in ipairs(issues.sort(issues.errors)) do
   assert(warning[1] == "s207")
   assert(warning[2] == "malformed quark or scan mark name")
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/s207-04.lua
+++ b/explcheck/testfiles/s207-04.lua
@@ -8,10 +8,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local _, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/w100-01.lua
+++ b/explcheck/testfiles/w100-01.lua
@@ -7,8 +7,9 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 
-preprocessing(issues, filename, content)
+preprocessing(filename, content, issues, results)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/w100-02.lua
+++ b/explcheck/testfiles/w100-02.lua
@@ -7,8 +7,9 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 
-preprocessing(issues, filename, content)
+preprocessing(filename, content, issues, results)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/w100-03.lua
+++ b/explcheck/testfiles/w100-03.lua
@@ -7,8 +7,9 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 
-preprocessing(issues, filename, content)
+preprocessing(filename, content, issues, results)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 0)

--- a/explcheck/testfiles/w100.lua
+++ b/explcheck/testfiles/w100.lua
@@ -7,8 +7,9 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 
-preprocessing(issues, filename, content)
+preprocessing(filename, content, issues, results)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 1)

--- a/explcheck/testfiles/w101.lua
+++ b/explcheck/testfiles/w101.lua
@@ -8,8 +8,9 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 
-local line_starting_byte_numbers = preprocessing(issues, filename, content)
+preprocessing(filename, content, issues, results)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 2)
@@ -19,8 +20,8 @@ for index, warning in ipairs(issues.sort(issues.warnings)) do
   assert(warning[1] == "w101")
   assert(warning[2] == "unexpected delimiters")
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/w200.lua
+++ b/explcheck/testfiles/w200.lua
@@ -10,10 +10,11 @@ local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
 issues:ignore('s205')
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 4)
@@ -23,8 +24,8 @@ for index, warning in ipairs(issues.sort(issues.warnings)) do
   assert(warning[1] == "w200")
   assert(warning[2] == '"do not use" argument specifiers')
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end

--- a/explcheck/testfiles/w202.lua
+++ b/explcheck/testfiles/w202.lua
@@ -9,10 +9,11 @@ local file = assert(io.open(filename, "r"))
 local content = assert(file:read("*a"))
 assert(file:close())
 local issues = new_issues()
+local results = {}
 local options = {expl3_detection_strategy = "always"}
 
-local line_starting_byte_numbers, expl_ranges = preprocessing(issues, filename, content, options)
-lexical_analysis(issues, filename, content, expl_ranges, options)
+preprocessing(filename, content, issues, results, options)
+lexical_analysis(filename, content, issues, results, options)
 
 assert(#issues.errors == 0)
 assert(#issues.warnings == 1)
@@ -22,8 +23,8 @@ for index, warning in ipairs(issues.sort(issues.warnings)) do
   assert(warning[1] == "w202")
   assert(warning[2] == "deprecated control sequences")
   local byte_range = warning[3]
-  local start_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:start())
-  local end_line_number = utils.convert_byte_to_line_and_column(line_starting_byte_numbers, byte_range:stop())
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
   assert(start_line_number == expected_line_numbers[index])
   assert(end_line_number == expected_line_numbers[index])
 end


### PR DESCRIPTION
This PR makes the following change:

- Stabilize the Lua API of processing steps to:
  1. The filename of a processed file
  2. The content of the processed file
  3. A registry of issues with the processed file (write-only)
  4. Intermediate analysis results (read-write)
  5. Options (read-only, optional)
- Update `CHANGES.md`

This PR also makes the following changes:
- Replace needless bracket notation in `explcheck-config.lua`.