### PR TITLE
Preconfigure packages with false positive error detections

### DIFF
--- a/explcheck/src/explcheck-config.toml
+++ b/explcheck/src/explcheck-config.toml
@@ -268,3 +268,6 @@ ignored_issues = ["e300"]
 
 [filename."spreadtab.sty"]
 expl3_detection_strategy = "never"
+
+[filename."ecgdraw.sty"]
+ignored_issues = ["e201"]

--- a/explcheck/src/explcheck-config.toml
+++ b/explcheck/src/explcheck-config.toml
@@ -265,3 +265,6 @@ ignored_issues = ["e301"]
 
 [package.zitie]
 ignored_issues = ["e300"]
+
+[filename."spreadtab.sty"]
+expl3_detection_strategy = "never"

--- a/explcheck/src/explcheck-config.toml
+++ b/explcheck/src/explcheck-config.toml
@@ -198,6 +198,7 @@ max_line_length = 140
 
 [filename."denisbdoc.sty"]
 expl3_detection_strategy = "always"
+ignored_issues = ["e201"]
 
 [package.whatsnote]
 expl3_detection_strategy = "always"

--- a/explcheck/testfiles/TL2016-issues.txt
+++ b/explcheck/testfiles/TL2016-issues.txt
@@ -82,13 +82,13 @@ ctexsize.sty s204,s205,w200
 ctexspamacro.tex s206,w200
 ctxdoc.cls s204,s206,w200,w202
 ctxdocstrip.tex s204
-denisbdoc.sty e201,s103,s204,s206,w200
+denisbdoc.sty s103,s204,s206,w200
 diffcoeff.sty s204,s205,w202
 diffcoeffx.sty s204,s205,w202
 download.sty s204
 download.tex s204
 dynamicnumber.sty s204
-ecgdraw.sty e201,s103,s204,s206
+ecgdraw.sty s103,s204,s206
 embrac.sty s204,w200,w202
 endiagram.sty s103,s204,w200
 enotez.sty s103,s204,s206,w200,w202

--- a/explcheck/testfiles/TL2017-issues.txt
+++ b/explcheck/testfiles/TL2017-issues.txt
@@ -73,7 +73,7 @@ ctexspamacro.tex s206,w200
 ctxdoc.cls s204,s206,w200,w202
 ctxdocstrip.tex s204
 currency.sty s204,w303
-denisbdoc.sty e201,s103,s204,s206,w200
+denisbdoc.sty s103,s204,s206,w200
 diffcoeff.sty s204,s205,w202
 diffcoeffx.sty s204,s205,w202
 download.sty s204
@@ -82,7 +82,7 @@ dynamicnumber.sty s204
 dynkin-diagrams.sty s204
 easyformat.sty s204
 ebproof.sty s103,s204,s206,w200
-ecgdraw.sty e201,s103,s204,s206
+ecgdraw.sty s103,s204,s206
 embrac.sty s204,w200,w202
 endiagram.sty s103,s204,w200
 enotez.sty s103,s204,s206,w200,w202

--- a/explcheck/testfiles/TL2018-issues.txt
+++ b/explcheck/testfiles/TL2018-issues.txt
@@ -78,7 +78,7 @@ ctxdoc.cls s204,s206,w200,w202
 ctxdocstrip.tex s204
 currency.sty s204,w303
 dashundergaps.sty s204,w302
-denisbdoc.sty e201,s103,s204,s206,w200
+denisbdoc.sty s103,s204,s206,w200
 diffcoeff.sty s103,s204
 download.sty s204
 ducksay.code.v1.tex s204,w100
@@ -89,7 +89,7 @@ dynamicnumber.sty s204
 dynkin-diagrams.sty s204
 easyformat.sty s204
 ebproof.sty s103,s204,s206,w200
-ecgdraw.sty e201,s103,s204,s206
+ecgdraw.sty s103,s204,s206
 embrac.sty s204,w200,w202
 endiagram.sty s103,s204,w200
 enotez.sty s103,s204,s206,w200,w202

--- a/explcheck/testfiles/TL2019-issues.txt
+++ b/explcheck/testfiles/TL2019-issues.txt
@@ -92,7 +92,7 @@ currency.sty s204,w303
 curve2e.sty s204
 dashundergaps.sty s204,w302
 ddphonism.sty s204
-denisbdoc.sty e201,s103,s204,s206,w200
+denisbdoc.sty s103,s204,s206,w200
 derivative.sty s103,s204
 diffcoeff.sty s103,s204
 download.sty s204
@@ -104,7 +104,7 @@ dynamicnumber.sty s204
 dynkin-diagrams.sty s204
 easyformat.sty s204
 ebproof.sty s103,s204,s206,w200
-ecgdraw.sty e201,s103,s204,s206
+ecgdraw.sty s103,s204,s206
 elzcards.sty s103,s204
 embrac.sty s204,w200,w202
 emoji.sty e209,s103,s204
@@ -296,7 +296,6 @@ skrapport-size-common.sty s204
 skrapport.cls s204,s205,s206
 soup.sty s103,s204,s206,w302
 spath3.sty s103,s204,s206,w202
-spreadtab.sty s103,s204
 sseqcheckdefinitions.code.tex s103,s204
 sseqdrawing.code.tex s103,s204
 sseqforeach.code.tex s103,s204

--- a/explcheck/testfiles/TL2020-issues.txt
+++ b/explcheck/testfiles/TL2020-issues.txt
@@ -107,7 +107,7 @@ curve2e.sty s204
 dashundergaps.sty s204,w302
 ddphonism.sty s204
 decision-table.sty s103
-denisbdoc.sty e201,s103,s204,s206,w200
+denisbdoc.sty s103,s204,s206,w200
 derivative.sty s103,s204
 diagbox.sty s103,s204
 diffcoeff.sty s103,s204
@@ -123,7 +123,7 @@ dynkin-diagrams.sty s204
 easybook.cls s103,s204,s205,s206
 easyformat.sty s204
 ebproof.sty s103,s204,s206,w200
-ecgdraw.sty e201,s103,s204,s206
+ecgdraw.sty s103,s204,s206
 econlipsum.sty s103,s204,w200,w202
 elsarticle.cls s103,s204,w202
 elzcards.sty s103,s204
@@ -377,7 +377,6 @@ skrapport.cls s204,s205,s206
 soup.sty s103,s204,s206,w302
 source2edoc.cls s103,s204,w302
 spath3.sty s103,s204,s206,w202
-spreadtab.sty s103,s204
 sseqcheckdefinitions.code.tex s103,s204
 sseqdrawing.code.tex s103,s204
 sseqforeach.code.tex s103,s204

--- a/explcheck/testfiles/TL2021-issues.txt
+++ b/explcheck/testfiles/TL2021-issues.txt
@@ -116,7 +116,7 @@ dashundergaps.sty s204,w302
 dbshow.sty s103,s204,s205,s206
 ddphonism.sty s204
 decision-table.sty s103,s204,s206
-denisbdoc.sty e201,s103,s204,s206,w200
+denisbdoc.sty s103,s204,s206,w200
 derivative.sty s103,s204
 diagbox.sty s103,s204
 diffcoeff.sty s103,s204
@@ -136,7 +136,7 @@ easybase.sty s103,s204,s206
 easybook.cls s103,s204
 easyformat.sty s204
 ebproof.sty s103,s204,s206,w200
-ecgdraw.sty e201,s103,s204,s206
+ecgdraw.sty s103,s204,s206
 econlipsum.sty s103,s204,w200,w202
 einfart.cls s103,s204
 elsarticle.cls s103,s204,w202
@@ -493,7 +493,6 @@ soup.sty s103,s204,s206,w302
 source2edoc.cls s103,s204,s206,w200,w302
 spath3.sty s103,s204,s206,w202
 spbmark.sty s103,s204
-spreadtab.sty s103,s204
 sseqcheckdefinitions.code.tex s204
 sseqdrawing.code.tex s103,s204
 sseqforeach.code.tex s103,s204

--- a/explcheck/testfiles/TL2022-issues.txt
+++ b/explcheck/testfiles/TL2022-issues.txt
@@ -140,7 +140,7 @@ dbshow.sty s103,s204,s205,s206
 ddphonism.sty s204
 decision-table.sty s103,s204,s206
 democodelisting.sty s204
-denisbdoc.sty e201,s103,s204,s206,w200,w202
+denisbdoc.sty s103,s204,s206,w200,w202,w302
 derivative.sty s103,s204
 diagbox.sty s103,s204
 diffcoeff.sty s204,w302
@@ -160,7 +160,7 @@ easybase.sty s103,s204,s206
 easybook.cls s103,s204
 easyformat.sty s204
 ebproof.sty s103,s204,s206,w200
-ecgdraw.sty e201,s103,s204,s206
+ecgdraw.sty s103,s204,s206
 econlipsum.sty s103,s204,w200,w202
 einfart.cls s103,s204
 elsarticle.cls s103,s204,w202
@@ -577,7 +577,6 @@ soup.sty s103,s204,s206,w302
 source2edoc.cls s103,s204,s206,w200,w302
 spath3.sty s103,s204,s206,w202
 spbmark.sty s103,s204
-spreadtab.sty s103,s204
 srdp-mathematik.sty s204
 sseqcheckdefinitions.code.tex s103,s204
 sseqdrawing.code.tex s103,s204

--- a/explcheck/testfiles/TL2023-issues.txt
+++ b/explcheck/testfiles/TL2023-issues.txt
@@ -168,7 +168,7 @@ dbshow.sty s103,s204,s205,s206
 ddphonism.sty s204
 decision-table.sty s103,s204,s206
 democodelisting.sty s204
-denisbdoc.sty e201,s103,s204,s206,w200,w202
+denisbdoc.sty s103,s204,s206,w200,w202,w302
 derivative.sty s103,s204
 diagbox.sty s103,s204
 didec.sty s103,s204
@@ -188,7 +188,7 @@ easybase.sty s103,s204,s206
 easybook.cls s103,s204
 easyformat.sty s204
 ebproof.sty s103,s204,s206,w200
-ecgdraw.sty e201,s103,s204,s206
+ecgdraw.sty s103,s204,s206
 econlipsum.sty s103,s204,w200,w202
 einfart.cls s103,s204
 elsarticle.cls s103,s204,w202
@@ -651,7 +651,6 @@ soup.sty s103,s204,s206,w302
 source2edoc.cls s103,s204,s206,w200,w302
 spath3.sty s103,s204,s206,w202
 spbmark.sty s103,s204
-spreadtab.sty s103,s204
 srdp-mathematik.sty s204
 sseqcheckdefinitions.code.tex s103,s204
 sseqdrawing.code.tex s103,s204

--- a/explcheck/testfiles/TL2024-issues.txt
+++ b/explcheck/testfiles/TL2024-issues.txt
@@ -198,7 +198,7 @@ dbshow.sty s103,s204,s205,s206
 ddphonism.sty s204
 decision-table.sty s103,s204,s206
 democodelisting.sty s204
-denisbdoc.sty e201,s103,s204,s206,w200,w202
+denisbdoc.sty s103,s204,s206,w200,w202,w302
 derivative.sty s103,s204
 diagbox.sty s103,s204
 didec.sty s103,s204
@@ -218,7 +218,7 @@ easybase.sty s103,s204,s206,w200
 easybook.cls s103,s204
 easyformat.sty s204
 ebproof.sty s103,s204,s206,w200
-ecgdraw.sty e201,s103,s204,s206
+ecgdraw.sty s103,s204,s206
 econlipsum.sty s103,s204,w200,w202
 einfart.cls s103,s204
 electrum.sty s204
@@ -752,7 +752,6 @@ source2edoc.cls s103,s204
 spath3.sty s103,s204,s206
 spbmark.sty s103,s204
 spelatex.sty s204,w303
-spreadtab.sty s103,s204,w100
 srdp-mathematik.sty s204
 sseqcheckdefinitions.code.tex s103,s204
 sseqdrawing.code.tex s103,s204


### PR DESCRIPTION
This PR preconfigures the packages `spreadtab.sty`, `ecgdraw.sty`, and `denisbdoc.sty` with false positive error detections.