### PR TITLE
Continuously prune the default config file `explcheck-config.toml`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,7 @@ jobs:
         with:
           submodules: true
       - name: Install TeX Live
+        if: matrix.release != 'latest'
         uses: teatimeguest/setup-texlive-action@v3
         with:
           packages: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-schedule:
-  - cron: '30 4 * * MON'
+  schedule:
+    - cron: '30 4 * * MON'
 env:
   DEBIAN_FRONTEND: noninteractive
 jobs:
@@ -107,7 +107,7 @@ jobs:
           - TL2024
           - latest
     container:
-      image: texlive/texlive:${{ matrix.release == "latest" && "latest" || matrix.release + "-historic" }}
+      image: texlive/texlive:${{ matrix.release == 'latest' && 'latest' || format('{0}-historic', matrix.release) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -156,17 +156,17 @@ jobs:
             }
           }' > issues.txt
       - name: Upload issues
-        if: matrix.release != "latest"
+        if: matrix.release != 'latest'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.release }} issues
           path: |
             issues.txt
       - name: Compare issues against the baselines
-        if: matrix.release != "latest"
+        if: matrix.release != 'latest'
         run: git diff --no-index --word-diff-regex=. --color=always explcheck/testfiles/${{ matrix.release }}-issues.txt issues.txt
       - name: Check if the configuration is minimal
-        if: matrix.release == "latest"
+        if: matrix.release == 'latest'
         run: |
           set -e
           export LUAINPUTS=explcheck/src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+schedule:
+  - cron: '30 4 * * MON'
 env:
   DEBIAN_FRONTEND: noninteractive
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,6 +160,11 @@ jobs:
             issues.txt
       - name: Compare issues
         run: git diff --no-index --word-diff-regex=. --color=always explcheck/testfiles/${{ matrix.release }}-issues.txt issues.txt
+      - name: Check if the configuration is minimal
+        run: |
+          set -e
+          export LUAINPUTS=explcheck/src
+          explcheck/src/prune-explcheck-config.lua explcheck/testfiles/${{ matrix.release }}-issues.txt
   artifacts:
     name: Build and publish artifacts
     needs: [luacheck, explcheck, shellcheck, unit-tests, regression-tests]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,8 +103,9 @@ jobs:
           - TL2022
           - TL2023
           - TL2024
+          - latest
     container:
-      image: texlive/texlive:${{ matrix.release }}-historic
+      image: texlive/texlive:${{ matrix.release == "latest" && "latest" || matrix.release + "-historic" }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -153,18 +154,21 @@ jobs:
             }
           }' > issues.txt
       - name: Upload issues
+        if: matrix.release != "latest"
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.release }} issues
           path: |
             issues.txt
-      - name: Compare issues
+      - name: Compare issues against the baselines
+        if: matrix.release != "latest"
         run: git diff --no-index --word-diff-regex=. --color=always explcheck/testfiles/${{ matrix.release }}-issues.txt issues.txt
       - name: Check if the configuration is minimal
+        if: matrix.release == "latest"
         run: |
           set -e
           export LUAINPUTS=explcheck/src
-          explcheck/src/prune-explcheck-config.lua explcheck/testfiles/${{ matrix.release }}-issues.txt
+          texlua explcheck/src/prune-explcheck-config.lua issues.txt
   artifacts:
     name: Build and publish artifacts
     needs: [luacheck, explcheck, shellcheck, unit-tests, regression-tests]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@
   configuration can be removed without affecting the results of the static
   analysis. This reminds the maintainer to remove the outdated configurations.
 
+- Run CI every Monday morning, after the weekly TeX Live Docker image has
+  released. (#78)
+
 ## expltools 2025-04-25
 
 ### explcheck v0.9.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,9 @@
 
 #### Continuous integration
 
-- Continuously prune file `explcheck-config.toml`. (#78)
+- Continuously prune the default config file `explcheck-config.toml`. (#78)
 
-  The default configuration file `explcheck-config.toml` preconfigures many
+  The default config file `explcheck-config.toml` preconfigures many
   packages to prevent false positive detections of issues. However, as the
   capabilities of explcheck grow, many of these configurations are outdated
   and no longer necessary.
@@ -16,7 +16,7 @@
   This change adds a script `prune-explcheck-config.lua` that reads the default
   configuration and regression test results and then tests which parts of the
   configuration can be removed without affecting the results of the static
-  analysis. This allows the maintainer to remove the outdated configurations.
+  analysis. This reminds the maintainer to remove the outdated configurations.
 
 ## expltools 2025-04-25
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
   This change adds a script `prune-explcheck-config.lua` that reads the default
   configuration and regression test results and then tests which parts of the
   configuration can be removed without affecting the results of the static
-  analysis. This reminds the maintainer to remove the outdated configurations.
+  analysis. Then, the script reminds the maintainer to remove these parts.
 
 - Run CI every Monday morning, after the weekly TeX Live Docker image has
   released. (#78)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,11 @@
 - Run CI every Monday morning, after the weekly TeX Live Docker image has
   released. (#78)
 
+#### Documentation
+
+- Include the date of generation and the latest obsolete entry in the generated
+  file `explcheck-obsolete.lua`. (#78)
+
 ## expltools 2025-04-25
 
 ### explcheck v0.9.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,20 @@
 
 ### explcheck v0.10.0
 
+#### Continuous integration
+
+- Continuously prune file `explcheck-config.toml`. (#78)
+
+  The default configuration file `explcheck-config.toml` preconfigures many
+  packages to prevent false positive detections of issues. However, as the
+  capabilities of explcheck grow, many of these configurations are outdated
+  and no longer necessary.
+
+  This change adds a script `prune-explcheck-config.lua` that reads the default
+  configuration and regression test results and then tests which parts of the
+  configuration can be removed without affecting the results of the static
+  analysis. This allows the maintainer to remove the outdated configurations.
+
 ## expltools 2025-04-25
 
 ### explcheck v0.9.0

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -2,18 +2,12 @@
 
 local evaluation = require("explcheck-evaluation")
 local format = require("explcheck-format")
-local get_option = require("explcheck-config")
+local get_option = require("explcheck-config").get_option
 local new_issues = require("explcheck-issues")
 local utils = require("explcheck-utils")
 
 local new_file_results = evaluation.new_file_results
 local new_aggregate_results = evaluation.new_aggregate_results
-
-local preprocessing = require("explcheck-preprocessing")
-local lexical_analysis = require("explcheck-lexical-analysis")
-local syntactic_analysis = require("explcheck-syntactic-analysis")
-local semantic_analysis = require("explcheck-semantic-analysis")
--- local pseudo_flow_analysis = require("explcheck-pseudo-flow-analysis")
 
 -- Deduplicate pathnames.
 local function deduplicate_pathnames(pathnames)
@@ -90,18 +84,10 @@ local function main(pathnames, options)
       assert(file:close())
 
       -- Run all steps.
-      local steps = {preprocessing, lexical_analysis, syntactic_analysis, semantic_analysis}
       local analysis_results = {}
-      for _, step in ipairs(steps) do
-        step.process(pathname, content, issues, analysis_results, options)
-        -- If a processing step ended with error, skip all following steps.
-        if #issues.errors > 0 then
-          goto skip_remaining_steps
-        end
-      end
+      utils.process_with_all_steps(pathname, content, issues, analysis_results, options)
 
       -- Print warnings and errors.
-      ::skip_remaining_steps::
       local file_evaluation_results = new_file_results(content, analysis_results, issues)
       aggregate_evaluation_results:add(file_evaluation_results)
       local is_last_file = pathname_number == #pathnames

--- a/explcheck/src/explcheck-config.lua
+++ b/explcheck/src/explcheck-config.lua
@@ -21,6 +21,16 @@ local default_config = read_config_file(default_config_pathname)
 -- Load the user-defined configuration from the config file .explcheckrc (if it exists).
 local user_config = read_config_file(".explcheckrc")
 
+-- Get the filename of a file.
+local function get_filename(pathname)
+  return utils.get_basename(pathname)
+end
+
+-- Get the package name of a file.
+local function get_package(pathname)
+  return utils.get_basename(utils.get_parent(pathname))
+end
+
 -- Get the value of an option.
 local function get_option(key, options, pathname)
   -- If a table of options is provided and the option is specified there, use it.
@@ -31,12 +41,12 @@ local function get_option(key, options, pathname)
   for _, config in ipairs({user_config, default_config}) do
     if pathname ~= nil then
       -- If a pathname is provided and the current configuration specifies the option for this filename, use it.
-      local filename = utils.get_basename(pathname)
+      local filename = get_filename(pathname)
       if config.filename and config.filename[filename] ~= nil and config.filename[filename][key] ~= nil then
         return config.filename[filename][key]
       end
       -- If a pathname is provided and the current configuration specifies the option for this package, use it.
-      local package = utils.get_basename(utils.get_parent(pathname))
+      local package = get_package(pathname)
       if config.package and config.package[package] ~= nil and config.package[package][key] ~= nil then
         return config.package[package][key]
       end
@@ -51,4 +61,11 @@ local function get_option(key, options, pathname)
   error('Failed to get a value for option "' .. key .. '"')
 end
 
-return get_option
+return {
+  default_config = default_config,
+  default_config_pathname = default_config_pathname,
+  get_filename = get_filename,
+  get_option = get_option,
+  get_package = get_package,
+  user_config = user_config,
+}

--- a/explcheck/src/explcheck-config.toml
+++ b/explcheck/src/explcheck-config.toml
@@ -17,18 +17,12 @@ max_line_length = 140
 [filename."tex4ht.sty"]
 expl3_detection_strategy = "precision"
 
-[filename."nicematrix.sty"]
-expl3_detection_strategy = "always"
-
 [package.xint]
 expl3_detection_strategy = "precision"
 
 [filename."xCJK2uni.sty"]
 expl3_detection_strategy = "always"
 ignored_issues = ["e209"]
-
-[filename."spath3.sty"]
-expl3_detection_strategy = "always"
 
 [package.xparse]
 expl3_detection_strategy = "always"
@@ -39,20 +33,7 @@ max_line_length = 90
 expl3_detection_strategy = "always"
 max_line_length = 90
 
-[filename."hobby.code.tex"]
-expl3_detection_strategy = "always"
-max_line_length = 90
-
-[filename."gtl.sty"]
-expl3_detection_strategy = "always"
-
-[filename."piton.sty"]
-expl3_detection_strategy = "always"
-ignored_issues = ["e208"]
-max_line_length = 90
-
 [filename."statistics.sty"]
-expl3_detection_strategy = "always"
 max_line_length = 100
 
 [filename."chemmacros.sty"]
@@ -65,12 +46,6 @@ expl3_detection_strategy = "precision"
 expl3_detection_strategy = "always"
 max_line_length = 150
 ignored_issues = ["e300"]
-
-[filename."namedef.sty"]
-expl3_detection_strategy = "always"
-
-[filename."tikzlibrarytikzmark.code.tex"]
-expl3_detection_strategy = "always"
 
 [package.ctex]
 expl3_detection_strategy = "always"
@@ -93,11 +68,9 @@ expl3_detection_strategy = "always"
 max_line_length = 110
 
 [filename."qrbill.sty"]
-expl3_detection_strategy = "always"
 max_line_length = 180
 
 [filename."cleveref-forward.sty"]
-expl3_detection_strategy = "always"
 max_line_length = 160
 
 [filename."latexrelease.sty"]
@@ -122,7 +95,6 @@ expl3_detection_strategy = "precision"
 ignored_issues = ["e201"]
 
 [filename."csvsimple-l3.sty"]
-expl3_detection_strategy = "always"
 max_line_length = 110
 
 [package.unicode-math]
@@ -149,9 +121,6 @@ expl3_detection_strategy = "precision"
 [package.exam-zh]
 ignored_issues = ["e209", "e301"]
 max_line_length = 150
-
-[filename."lwarp-statistics.sty"]
-expl3_detection_strategy = "always"
 
 [filename."platexrelease.sty"]
 expl3_detection_strategy = "always"
@@ -195,7 +164,6 @@ ignored_issues = ["e209"]
 ignored_issues = ["e209"]
 
 [filename."beamerouterthemeUR.sty"]
-expl3_detection_strategy = "always"
 max_line_length = 140
 
 [filename."denisbdoc.sty"]
@@ -205,22 +173,13 @@ ignored_issues = ["e201"]
 [package.whatsnote]
 expl3_detection_strategy = "always"
 
-[filename."robust-externalize.sty"]
-expl3_detection_strategy = "always"
-
 [filename."multicolrule.sty"]
-expl3_detection_strategy = "always"
 max_line_length = 100
-
-[package.minimalist]
-expl3_detection_strategy = "always"
 
 [filename."xtemplate.sty"]
 expl3_detection_strategy = "always"
-max_line_length = 100
 
 [package.ocgx2]
-expl3_detection_strategy = "always"
 max_line_length = 100
 
 [package.tuda-ci]
@@ -230,7 +189,6 @@ expl3_detection_strategy = "always"
 ignored_issues = ["e209"]
 
 [package.media9]
-expl3_detection_strategy = "always"
 max_line_length = 140
 
 [filename."nwejm.cls"]
@@ -241,11 +199,7 @@ expl3_detection_strategy = "always"
 max_line_length = 120
 
 [filename."letterswitharrows.sty"]
-expl3_detection_strategy = "always"
 max_line_length = 110
-
-[filename."ufrgscca.cls"]
-expl3_detection_strategy = "always"
 
 [filename."keythms-amsart-support.tex"]
 expl3_detection_strategy = "always"

--- a/explcheck/src/explcheck-format.lua
+++ b/explcheck/src/explcheck-format.lua
@@ -1,7 +1,7 @@
 -- Formatting for the command-line interface of the static analyzer explcheck.
 
 local statement_types = require("explcheck-semantic-analysis").statement_types
-local get_option = require("explcheck-config")
+local get_option = require("explcheck-config").get_option
 local utils = require("explcheck-utils")
 
 local FUNCTION_DEFINITION = statement_types.FUNCTION_DEFINITION

--- a/explcheck/src/explcheck-issues.lua
+++ b/explcheck/src/explcheck-issues.lua
@@ -123,6 +123,34 @@ function Issues:ignore(identifier, range)
   table.insert(self.ignored_issues, ignore_issue)
 end
 
+-- Check whether two registries only contain issues with the same codes.
+function Issues:has_same_codes_as(other)
+  -- Collect codes of all issues.
+  local self_codes, other_codes = {}, {}
+  for _, table_name in ipairs({'warnings', 'errors'}) do
+    for _, tables in ipairs({{self[table_name], self_codes}, {other[table_name], other_codes}}) do
+      local issue_table, codes = table.unpack(tables)
+      for _, issue in ipairs(issue_table) do
+        local code = issue[1]
+        codes[code] = true
+      end
+    end
+  end
+  -- Check whether this registry has any extra codes.
+  for code, _ in pairs(self_codes) do
+    if other_codes[code] == nil then
+      return false
+    end
+  end
+  -- Check whether the other registry has any extra codes.
+  for code, _ in pairs(other_codes) do
+    if self_codes[code] == nil then
+      return false
+    end
+  end
+  return true
+end
+
 -- Sort the warnings/errors using location as the primary key.
 function Issues.sort(warnings_and_errors)
   local sorted_warnings_and_errors = {}

--- a/explcheck/src/explcheck-lexical-analysis.lua
+++ b/explcheck/src/explcheck-lexical-analysis.lua
@@ -1,6 +1,6 @@
 -- The lexical analysis step of static analysis converts expl3 parts of the input files into TeX tokens.
 
-local get_option = require("explcheck-config")
+local get_option = require("explcheck-config").get_option
 local ranges = require("explcheck-ranges")
 local obsolete = require("explcheck-obsolete")
 local parsers = require("explcheck-parsers")

--- a/explcheck/src/explcheck-preprocessing.lua
+++ b/explcheck/src/explcheck-preprocessing.lua
@@ -1,6 +1,6 @@
 -- The preprocessing step of static analysis determines which parts of the input files contain expl3 code.
 
-local get_option = require("explcheck-config")
+local get_option = require("explcheck-config").get_option
 local ranges = require("explcheck-ranges")
 local parsers = require("explcheck-parsers")
 local utils = require("explcheck-utils")

--- a/explcheck/src/explcheck-utils.lua
+++ b/explcheck/src/explcheck-utils.lua
@@ -35,9 +35,25 @@ local function get_parent(pathname)
   end
 end
 
---- Return all parameters unchanged, mostly used for no-op map-back and map-forward functions.
+-- Return all parameters unchanged, mostly used for no-op map-back and map-forward functions.
 local function identity(...)
   return ...
+end
+
+-- Run all processing steps.
+local function process_with_all_steps(pathname, content, issues, analysis_results, options)
+  local preprocessing = require("explcheck-preprocessing")
+  local lexical_analysis = require("explcheck-lexical-analysis")
+  local syntactic_analysis = require("explcheck-syntactic-analysis")
+  local semantic_analysis = require("explcheck-semantic-analysis")
+  local steps = {preprocessing, lexical_analysis, syntactic_analysis, semantic_analysis}
+  for _, step in ipairs(steps) do
+    step.process(pathname, content, issues, analysis_results, options)
+    -- If a processing step ended with error, skip all following steps.
+    if #issues.errors > 0 then
+      return
+    end
+  end
 end
 
 return {
@@ -46,4 +62,5 @@ return {
   get_parent = get_parent,
   get_suffix = get_suffix,
   identity = identity,
+  process_with_all_steps = process_with_all_steps,
 }

--- a/explcheck/src/prune-explcheck-config.lua
+++ b/explcheck/src/prune-explcheck-config.lua
@@ -138,7 +138,7 @@ local function main(results_pathname)
     num_options,
     num_filenames,
     num_possible_removals,
-    results_pathname,
+    results_pathname
   ))
 end
 

--- a/explcheck/src/prune-explcheck-config.lua
+++ b/explcheck/src/prune-explcheck-config.lua
@@ -82,7 +82,7 @@ local function main(results_pathname)
     end
   end
 
-  -- Try to remove all options in a section of the configuration file.
+  -- Try to remove all options in a section of the config file.
   local function try_to_remove_all_options(pathname, options, options_location, expected_issues)
     local keys = {}
     for key, _ in pairs(options) do

--- a/explcheck/src/prune-explcheck-config.lua
+++ b/explcheck/src/prune-explcheck-config.lua
@@ -2,12 +2,9 @@
 -- A checker that reads the default configuration of the static analyzer explcheck and regression test results
 -- and then tests which parts of the configuration can be removed without affecting the results of the static analysis.
 
--- Initialize KPathSea.
 local kpse = require("kpse")
+kpse.set_program_name("texlua", "prune-explcheck-config")
 
-kpse.set_program_name("texlua", "explcheck")
-
--- Load modules.
 local config = require("explcheck-config")
 local new_issues = require("explcheck-issues")
 local process_with_all_steps = require("explcheck-utils").process_with_all_steps

--- a/explcheck/src/prune-explcheck-config.lua
+++ b/explcheck/src/prune-explcheck-config.lua
@@ -114,11 +114,7 @@ local function main(results_pathname)
   end
 
   -- Try to remove all options for the individual files from the test results.
-  local max_previous_filename_length = 0
   for _, filename in ipairs(results.filenames) do
-    io.write(string.format('\rChecking "%s" ...%s', filename, (' '):rep(math.max(0, max_previous_filename_length - #filename))))
-    max_previous_filename_length = math.max(max_previous_filename_length, #filename)
-    io.flush()
     num_filenames = num_filenames + 1
     local pathname = results.pathnames[filename]
     local expected_issues = results.issues[filename]
@@ -136,7 +132,6 @@ local function main(results_pathname)
       try_to_remove_all_options(pathname, default_config.package[package], options_location, expected_issues)
     end
   end
-  io.write('\r')
 
   -- Print all options that can be removed without affecting any files from the test results.
   for _, key_location in ipairs(key_locations.seen) do
@@ -156,9 +151,9 @@ local function main(results_pathname)
   end
   io.write(string.format("Checked %d different options for %d files", num_options, num_filenames))
   if num_possible_removals == 0 then
-    io.write(string.format(', none of which can be removed without affecting results in file "%s"', results_pathname))
+    io.write(string.format(', none of which can be removed without affecting "%s"', results_pathname))
   else
-    io.write(string.format(', %d of which can be removed without affecting results in file "%s"', num_possible_removals, results_pathname))
+    io.write(string.format(', %d of which can be removed without affecting "%s"', num_possible_removals, results_pathname))
   end
   print(".")
   if num_possible_removals > 0 then

--- a/explcheck/src/prune-explcheck-config.lua
+++ b/explcheck/src/prune-explcheck-config.lua
@@ -21,6 +21,7 @@ local function read_results(results_pathname)
     pathnames = {},
     issues = {},
   }
+  print(string.format('Reading regression test results from file "%s" ...', results_pathname))
   for line in io.lines(results_pathname) do
     local line_filename, issues = line:match("^(%S+)%s+(%S+)$")
     assert(line_filename ~= nil)
@@ -51,7 +52,7 @@ local function main(results_pathname)
   -- Read the results.
   local results = read_results(results_pathname)
 
-  local num_filenames, num_options, num_possible_removals = 0, 0, 0
+  local num_options, num_possible_removals = 0, 0
   local key_locations = {
     seen = {},
     results = {},
@@ -111,21 +112,21 @@ local function main(results_pathname)
   end
 
   -- Try to remove all options for the individual files from the test results.
+  print(string.format('Checking all options for %d files in the default config file "%s" ...', #results.filenames, default_config_pathname))
   for _, filename in ipairs(results.filenames) do
-    num_filenames = num_filenames + 1
     local pathname = results.pathnames[filename]
     local expected_issues = results.issues[filename]
     assert(pathname ~= nil)
     assert(expected_issues ~= nil)
     -- If the configuration specifies options for this filename, check them.
     if default_config.filename and default_config.filename[filename] ~= nil then
-      local options_location = string.format('section [filename."%s"] of file "%s"', filename, default_config_pathname)
+      local options_location = string.format('section [filename."%s"]', filename)
       try_to_remove_all_options(pathname, default_config.filename[filename], options_location, expected_issues)
     end
     -- If the configuration specifies options for this package, check them.
     local package = get_package(pathname)
     if default_config.package and default_config.package[package] ~= nil then
-      local options_location = string.format('section [package."%s"] of file "%s"', package, default_config_pathname)
+      local options_location = string.format('section [package."%s"]', package)
       try_to_remove_all_options(pathname, default_config.package[package], options_location, expected_issues)
     end
   end
@@ -146,7 +147,7 @@ local function main(results_pathname)
   if num_possible_removals > 0 then
     print()
   end
-  io.write(string.format("Checked %d different options for %d files", num_options, num_filenames))
+  io.write(string.format("Checked %d different options", num_options))
   if num_possible_removals == 0 then
     io.write(string.format(', none of which can be removed without affecting "%s"', results_pathname))
   else

--- a/explcheck/src/prune-explcheck-config.lua
+++ b/explcheck/src/prune-explcheck-config.lua
@@ -2,6 +2,12 @@
 -- A checker that reads the default configuration of the static analyzer explcheck and regression test results
 -- and then tests which parts of the configuration can be removed without affecting the results of the static analysis.
 
+-- Initialize KPathSea.
+local kpse = require("kpse")
+
+kpse.set_program_name("texlua", "explcheck")
+
+-- Load modules.
 local config = require("explcheck-config")
 local new_issues = require("explcheck-issues")
 local process_with_all_steps = require("explcheck-utils").process_with_all_steps
@@ -10,15 +16,8 @@ local default_config = config.default_config
 local default_config_pathname = config.default_config_pathname
 local get_package = config.get_package
 
--- Initialize and return a handle for KPathSea.
-local function initialize_kpse()
-  local kpse = require("kpse")
-  kpse.set_program_name("texlua", "explcheck")
-  return kpse
-end
-
 -- Read regression test results and use KPathSea to find the files in the results.
-local function read_results(results_pathname, kpse)
+local function read_results(results_pathname)
   local num_skipped = 0
   local results = {
     filenames = {},
@@ -53,8 +52,7 @@ end
 -- whether this affects the results of the static analysis or not.
 local function main(results_pathname)
   -- Read the results.
-  local kpse = initialize_kpse()
-  local results = read_results(results_pathname, kpse)
+  local results = read_results(results_pathname)
 
   local num_filenames, num_options, num_possible_removals = 0, 0, 0
   local seen_key_locations = {}

--- a/explcheck/src/prune-explcheck-config.lua
+++ b/explcheck/src/prune-explcheck-config.lua
@@ -19,6 +19,7 @@ end
 
 -- Read regression test results and use KPathSea to find the files in the results.
 local function read_results(results_pathname, kpse)
+  local num_skipped = 0
   local results = {
     filenames = {},
     pathnames = {},
@@ -31,6 +32,7 @@ local function read_results(results_pathname, kpse)
     local line_pathname = kpse.find_file(line_filename)
     if line_pathname == nil then
       print(string.format('Could not determine the pathname of "%s" with KPathSea, skipping it.', line_filename))
+      num_skipped = num_skipped + 1
       goto continue
     end
     table.insert(results.filenames, line_filename)
@@ -40,6 +42,9 @@ local function read_results(results_pathname, kpse)
       results.issues[line_filename]:add(issue)
     end
     ::continue::
+  end
+  if num_skipped > 0 then
+    print()
   end
   return results
 end
@@ -133,13 +138,11 @@ local function main(results_pathname)
   if num_possible_removals > 0 then
     print()
   end
-  print(string.format(
-    'Checked %d different options for %d files, out of which %d can be removed without affecting correctness on file %s.',
-    num_options,
-    num_filenames,
-    num_possible_removals,
-    results_pathname
-  ))
+  io.write(string.format("Checked %d different options for %d files", num_options, num_filenames))
+  if num_possible_removals > 0 then
+    io.write(string.format(', out of which %d can be removed without affecting file "%s"', num_possible_removals, results_pathname))
+  end
+  print(".")
 end
 
 local function print_usage()

--- a/explcheck/src/prune-explcheck-config.lua
+++ b/explcheck/src/prune-explcheck-config.lua
@@ -1,0 +1,156 @@
+#!/usr/bin/env texlua
+-- A checker that reads the default configuration of the static analyzer explcheck and regression test results
+-- and then tests which parts of the configuration can be removed without affecting the results of the static analysis.
+
+local config = require("explcheck-config")
+local new_issues = require("explcheck-issues")
+local process_with_all_steps = require("explcheck-utils").process_with_all_steps
+
+local default_config = config.default_config
+local default_config_pathname = config.default_config_pathname
+local get_package = config.get_package
+
+-- Initialize and return a handle for KPathSea.
+local function initialize_kpse()
+  local kpse = require("kpse")
+  kpse.set_program_name("texlua", "explcheck")
+  return kpse
+end
+
+-- Read regression test results and use KPathSea to find the files in the results.
+local function read_results(results_pathname, kpse)
+  local results = {
+    filenames = {},
+    pathnames = {},
+    issues = {},
+  }
+  for line in io.lines(results_pathname) do
+    local line_filename, issues = line:match("^(%S+)%s+(%S+)$")
+    assert(line_filename ~= nil)
+    assert(issues ~= nil)
+    local line_pathname = kpse.find_file(line_filename)
+    if line_pathname == nil then
+      print(string.format('Could not determine the pathname of "%s" with KPathSea, skipping it.', line_filename))
+      goto continue
+    end
+    table.insert(results.filenames, line_filename)
+    results.pathnames[line_filename] = line_pathname
+    results.issues[line_filename] = new_issues()
+    for issue in issues:gmatch("[^,]+") do
+      results.issues[line_filename]:add(issue)
+    end
+    ::continue::
+  end
+  return results
+end
+
+-- For each file from regression test results, try to remove all options in the default configuration that apply to it and check
+-- whether this affects the results of the static analysis or not.
+local function main(results_pathname)
+  -- Read the results.
+  local kpse = initialize_kpse()
+  local results = read_results(results_pathname, kpse)
+
+  local num_filenames, num_options, num_possible_removals = 0, 0, 0
+  local seen_key_locations = {}
+
+  -- Try to remove a single option.
+  local function try_to_remove_option(pathname, key, key_location, default_value, expected_issues)
+    if seen_key_locations[key_location] ~= nil then
+      return
+    end
+    seen_key_locations[key_location] = true
+
+    num_options = num_options + 1
+
+    -- Run all steps of the static analysis.
+    local actual_issues = new_issues()
+    local options = {[key] = default_value}
+    local file = io.open(pathname, "r")
+    local content = assert(file:read("*a"))
+    assert(file:close())
+    local analysis_results = {}
+    process_with_all_steps(pathname, content, actual_issues, analysis_results, options)
+
+    -- Compare the expected results of the static analysis with the actual results.
+    if actual_issues:has_same_codes_as(expected_issues) then
+      num_possible_removals = num_possible_removals + 1
+      print(string.format('%s can be removed.', key_location))
+    end
+  end
+
+  -- Try to remove all options in a section of the configuration file.
+  local function try_to_remove_all_options(pathname, options, options_location, expected_issues)
+    local keys = {}
+    for key, _ in pairs(options) do
+      table.insert(keys, key)
+    end
+    table.sort(keys)
+    for _, key in ipairs(keys) do
+      local value = options[key]
+      assert(value ~= nil)
+      if type(value) == 'string' or type(value) == 'number' or type(value) == 'boolean' then
+        local default_value = default_config.defaults[key]
+        assert(default_value ~= nil)
+        local key_location = string.format('Option "%s" in %s', key, options_location)
+        try_to_remove_option(pathname, key, key_location, default_value, expected_issues)
+      elseif type(value) == 'table' then
+        for i, item in ipairs(value) do
+          local key_location = string.format('Item "%s" in option "%s" in %s', item, key, options_location)
+          local smaller_value = {}
+          for j = 1, #value do
+            if i ~= j then
+              table.insert(smaller_value, value[j])
+            end
+          end
+          try_to_remove_option(pathname, key, key_location, smaller_value, expected_issues)
+        end
+      end
+    end
+  end
+
+  -- Try to remove all options for the individual files from the test results.
+  for _, filename in ipairs(results.filenames) do
+    num_filenames = num_filenames + 1
+    local pathname = results.pathnames[filename]
+    local expected_issues = results.issues[filename]
+    assert(pathname ~= nil)
+    assert(expected_issues ~= nil)
+    -- If the configuration specifies options for this filename, check them.
+    if default_config.filename and default_config.filename[filename] ~= nil then
+      local options_location = string.format('section [filename."%s"] of file "%s"', filename, default_config_pathname)
+      try_to_remove_all_options(pathname, default_config.filename[filename], options_location, expected_issues)
+    end
+    -- If the configuration specifies options for this package, check them.
+    local package = get_package(pathname)
+    if default_config.package and default_config.package[package] ~= nil then
+      local options_location = string.format('section [package."%s"] of file "%s"', package, default_config_pathname)
+      try_to_remove_all_options(pathname, default_config.package[package], options_location, expected_issues)
+    end
+  end
+
+  -- Print the results.
+  if num_possible_removals > 0 then
+    print()
+  end
+  print(string.format(
+    'Checked %d different options for %d files, out of which %d can be removed without affecting correctness on file %s.',
+    num_options,
+    num_filenames,
+    num_possible_removals,
+    results_pathname,
+  ))
+end
+
+local function print_usage()
+  print("Usage: " .. arg[0] .. " TEST_RESULTS\n")
+  print("Test which parts of the default config file can be removed without affecting static analysis results.")
+end
+
+if #arg ~= 1 then
+  print_usage()
+  os.exit(1)
+else
+  local results_pathname = arg[1]
+  main(results_pathname)
+end

--- a/explcheck/testfiles/TL2013-issues.txt
+++ b/explcheck/testfiles/TL2013-issues.txt
@@ -42,8 +42,8 @@ fontspec-patches.sty s204,w302
 fontspec-xetex.sty s103,s204,s205,s206,w200,w302,w303
 fontspec.sty s103,s204,s205,s206,w202
 ghsystem.sty s103,s204,w200
-gtl.sty s204,s206,w302
-hobby.code.tex s204,s206,w303
+gtl.sty s206,w302
+hobby.code.tex s103,s204,s206,w303
 hobby_doc.tex s103,s204,w100
 hobete.sty s103,s204,s205,s206
 int_set_to_EAN_control_digit.tex s204,s206,w303
@@ -105,7 +105,6 @@ mandel.tex s204,s206
 mandi.sty s103,s204
 mathtools.sty e201,s103,s204,w100
 media9.sty s204,s206,w200,w202,w302
-media9.tex s103,s204
 metrix.sty s103,s204,s205
 mhchem.sty s103,s204,s205,s206,w303
 mhsetup.sty e201,s204,w100
@@ -159,7 +158,6 @@ texapi-doc.tex s103,s204
 texapi.tex s103,s204
 tikzlibrarycalligraphy.code.tex s103,s204
 tikzlibraryknots.code.tex s103,s204
-tikzlibrarytikzmark.code.tex s103,s204
 tikzscale.sty s204
 ufntinst.sty s103,s204,w100
 unicode-math-luatex.sty s204,s205,s206,w200,w302,w303
@@ -184,7 +182,7 @@ xparse.sty s204,s205,w200,w302
 xpatch.sty s103,s204,s206,w200
 xpeek.sty s206
 xpinyin.sty e209,s103,s204,w200
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 xunicode-symbols.tex e209,s103,s204,w200
 zhnumber.sty s103,s204,w101,w200,w202,w302,w303

--- a/explcheck/testfiles/TL2014-issues.txt
+++ b/explcheck/testfiles/TL2014-issues.txt
@@ -7,7 +7,6 @@ GS_set_EAN_control_digit.tex s204,s206,w303
 GS_set_code_digit_seq.tex s204,s206
 acro.sty s103,s204,s206,w200,w202,w302
 asts.tex s204
-beamerouterthemeUR.sty s103,s204
 bnumexpr.sty e201,s103,s204,w100
 breqn.sty s204
 caesar_book.cls s204
@@ -48,8 +47,8 @@ fontspec-patches.sty s204,w302
 fontspec-xetex.sty s103,s204,s205,s206,w200,w302
 fontspec.sty s103,s204,s206,w202
 ghsystem.sty s103,s204,w200
-gtl.sty s204,s206,w302
-hobby.code.tex s204,s206,w303
+gtl.sty s206,w302
+hobby.code.tex s103,s204,s206,w303
 hobby_doc.tex s103,s204,w100
 hobete.sty s103,s204,s205,s206
 int_set_to_EAN_control_digit.tex s204,s206,w303
@@ -122,7 +121,6 @@ luatexko.sty s103,s204,w302
 mandel.tex s204,s206
 mandi.sty s103,s204
 media9.sty s204,s206,w200,w202,w302
-media9.tex s103,s204
 memhangul-common.sty s204
 memhangul-ucs.sty s206
 metrix.sty s103,s204,s205
@@ -177,7 +175,6 @@ texapi.tex s103,s204
 tikzlibrarycalligraphy.code.tex s103,s204
 tikzlibraryceltic.code.tex s103,s204,s206,w202
 tikzlibraryknots.code.tex s103,s204
-tikzlibrarytikzmark.code.tex s103,s204
 tikzscale.sty s204
 ufntinst.sty s103,s204,w100
 unicode-math-luatex.sty s204,s205,s206,w200,w302,w303
@@ -204,7 +201,7 @@ xparse.sty s204,s205,w200,w302
 xpatch.sty s103,s204,s206,w200
 xpeek.sty s206
 xpinyin.sty s103,s204,w200,w302
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 xunicode-symbols.tex e209,s103,s204,w200
 zhnumber.sty s103,s204,w200,w202,w302

--- a/explcheck/testfiles/TL2015-issues.txt
+++ b/explcheck/testfiles/TL2015-issues.txt
@@ -8,7 +8,6 @@ GS_set_code_digit_seq.tex s204,s206
 acro.sty s103,s204,s206,w200,w202,w302
 acro_en.tex e102
 animate.sty s204
-beamerouterthemeUR.sty s103,s204
 bidi-media9.sty s204,s206
 breqn.sty s204
 caesar_book.cls s204
@@ -92,7 +91,7 @@ gtl.sty s204,s205,s206,w302
 gzt.cls e300,s103,s204,s205,s206,w302,w303
 gzt.tex s103,s204
 gztarticle.cls e300,s103,s204,s205,s206,w302,w303
-hobby.code.tex s204,s206,w303
+hobby.code.tex s103,s204,s206,w303
 hobby_doc.tex s103,s204,w100
 hobete.sty s103,s204,s205,s206
 int_set_to_EAN_control_digit.tex s204,s206,w303
@@ -164,7 +163,6 @@ luatexja-preset.sty s103,s204,s206,w202
 luatexko.sty s103,s204,w302
 mandi.sty s204
 media9.sty s204,s206,w200,w202,w302
-media9.tex s103,s204
 memhangul-common.sty s204
 memhangul-ucs.sty s206
 metrix.sty s103,s204,s205
@@ -224,7 +222,6 @@ texapi.tex s103,s204
 tikzlibrarycalligraphy.code.tex s103,s204,w202
 tikzlibraryceltic.code.tex s103,s204,s206,w202
 tikzlibraryknots.code.tex s103,s204,w202
-tikzlibrarytikzmark.code.tex s103,s204
 tikzscale.sty s204
 tikzsymbols.sty s103,s204,s206
 tudscrartcl.cls s204
@@ -259,7 +256,7 @@ xpeek.sty s206
 xpiano.sty s103,s204,w200
 xpinyin.sty s103,s204,w200,w302
 xsavebox.sty s204,s206,w200,w202,w302
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 xunicode-combine-marks.tex s204
 xunicode-commands.tex s103,s204

--- a/explcheck/testfiles/TL2016-issues.txt
+++ b/explcheck/testfiles/TL2016-issues.txt
@@ -112,7 +112,7 @@ gtl.sty s204,s205,s206,w302
 gzt-fr.tex s103,s204
 gzt.cls e300,s103,s204,s205,s206,w302,w303
 gztarticle.cls e300,s103,s204,s205,s206,w302,w303
-hobby.code.tex s204,s206,w303
+hobby.code.tex s103,s204,s206,w303
 hobby_doc.tex s103,s204,w100
 hobete.sty s103,s204,s205,s206
 int_set_to_EAN_control_digit.tex s204,s206,w303
@@ -189,7 +189,6 @@ lwarp-sidecap.sty s204
 mandi.sty s204
 mathspec.sty s204
 media9.sty s204,s206,w200,w202,w302
-media9.tex s103,s204
 memhangul-common.sty s204
 memhangul-ucs.sty s206
 metrix.sty s103,s204,s205
@@ -264,7 +263,6 @@ texapi.tex s103,s204
 tikzlibrarycalligraphy.code.tex s103,s204,w202
 tikzlibraryceltic.code.tex s103,s204,s206,w202
 tikzlibraryknots.code.tex s103,s204,w202
-tikzlibrarytikzmark.code.tex s103,s204
 tikzscale.sty s204
 tikzsymbols.sty s103,s204,s206
 unicode-math-doc.tex s103,s204,w302
@@ -296,7 +294,7 @@ xpeek.sty s206
 xpiano.sty s103,s204,w200
 xpinyin.sty s103,s204,w200,w302
 xsavebox.sty s204,s206,w200,w202,w302
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 xunicode-combine-marks.tex s204
 xunicode-commands.tex s103,s204

--- a/explcheck/testfiles/TL2017-issues.txt
+++ b/explcheck/testfiles/TL2017-issues.txt
@@ -106,7 +106,7 @@ ghsystem.sty s103,s204,w200,w202
 gtl.sty s204,s205,s206,w302
 gzt.cls e300,s103,s204,s205,s206,w302,w303
 gztarticle.cls e300,s103,s204,s205,s206,w302,w303
-hobby.code.tex s204,s206,w303
+hobby.code.tex s103,s204,s206,w303
 hobete.sty s103,s204,s205,s206
 interchar.sty s204,s206,w200,w202
 invoice2.sty s103,s204,w303
@@ -254,7 +254,6 @@ texapi.tex s103,s204
 tikzlibrarycalligraphy.code.tex s103,s204,w202
 tikzlibraryceltic.code.tex s103,s204,s206,w202
 tikzlibraryknots.code.tex s103,s204,w202
-tikzlibrarytikzmark.code.tex s103,s204
 tikzscale.sty s204
 tikzsymbols.sty s103,s204,s206,w202
 typoaid.sty s103,s204,s206
@@ -305,7 +304,7 @@ xsim.templates.code.tex s204,w100
 xsim.translations.code.tex s103,s204,w100
 xsim.verbwrite.code.tex s103,s204,w100
 xsimverb.sty s204
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 zhadobefonts.tex s204
 zhfandolfonts.tex s204

--- a/explcheck/testfiles/TL2018-issues.txt
+++ b/explcheck/testfiles/TL2018-issues.txt
@@ -120,7 +120,7 @@ ghsystem.sty s103,s204,w200,w202
 gtl.sty s204,s205,s206,w302
 gzt.cls e300,s103,s204,s205,s206,w202,w302,w303
 gztarticle.cls e300,s103,s204,s205,s206,w202,w302,w303
-hobby.code.tex s204,s206,w303
+hobby.code.tex s103,s204,s206,w303
 hobete.sty s103,s204,s205,s206
 interchar.sty s204,s206,w200,w202
 intopdf.sty s204,s206,w200
@@ -330,7 +330,7 @@ xsim.templates.code.tex s204,w100
 xsim.translations.code.tex s103,s204,w100
 xsim.verbwrite.code.tex s103,s204,w100
 xsimverb.sty s204
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 zhadobefonts.tex s204
 zhfandolfonts.tex s204

--- a/explcheck/testfiles/TL2018-issues.txt
+++ b/explcheck/testfiles/TL2018-issues.txt
@@ -131,7 +131,7 @@ kalendarium.sty s103,s204,w101
 kantlipsum.sty s103,s204,w200
 knowledge.sty s103,s204,s205,s206,w101,w202
 kvmap.sty s103,s204
-l3benchmark.sty s103,s204,s205,w200,w302
+l3benchmark.sty s103,s204,s205,w200,w202,w302
 l3cctab.sty s206,w200
 l3color.sty s103
 l3doc.cls s204,s206,w200,w303

--- a/explcheck/testfiles/TL2019-issues.txt
+++ b/explcheck/testfiles/TL2019-issues.txt
@@ -138,7 +138,7 @@ ghsystem.sty s103,s204,w200
 gtl.sty s204,s205,s206,w302
 gzt.cls e300,s103,s204,s205,s206,w202,w302,w303
 gztarticle.cls e300,s103,s204,s205,s206,w202,w302,w303
-hobby.code.tex s204,s206,w303
+hobby.code.tex s103,s204,s206,w303
 hobete.sty s103,s204,s205,s206
 hvfloat.sty s103,s204,s206
 interchar.sty s204,s206,w200,w202
@@ -390,7 +390,7 @@ xsim.templates.code.tex s204,w100
 xsim.translations.code.tex s103,s204,w100
 xsim.verbwrite.code.tex s103,s204,w100
 xsimverb.sty s204
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 zhadobefonts.tex s204
 zhfandolfonts.tex s204

--- a/explcheck/testfiles/TL2019-issues.txt
+++ b/explcheck/testfiles/TL2019-issues.txt
@@ -150,7 +150,7 @@ kalendarium.sty s103,s204,w101
 kantlipsum.sty s204,w200,w202
 knowledge.sty s103,s204,s205,s206,w101,w202
 kvmap.sty s103,s204
-l3benchmark.sty s103,s204,s205,w200,w302
+l3benchmark.sty s103,s204,s205,w200,w202,w302
 l3cctab.sty s204,s206,w200
 l3color.sty s103
 l3doc.cls s204,s206,w200,w303

--- a/explcheck/testfiles/TL2020-issues.txt
+++ b/explcheck/testfiles/TL2020-issues.txt
@@ -182,7 +182,7 @@ kalendarium.sty s103,s204,w101
 kantlipsum.sty s204,w200,w202
 knowledge.sty s103,s204,s205,s206,w101,w202
 kvmap.sty s103,s204
-l3benchmark.sty s103,s204,s205,w200,w302
+l3benchmark.sty s103,s204,s205,w200,w202,w302
 l3bitset.sty s103,w200
 l3doc.cls s204,s206,w200,w303
 l3docstrip.tex s204

--- a/explcheck/testfiles/TL2020-issues.txt
+++ b/explcheck/testfiles/TL2020-issues.txt
@@ -166,7 +166,7 @@ gtrcore.symbols.code.tex s204
 gtrlib.fanchart.code.tex s103,s204,s206
 gzt.cls e300,s103,s204,s205,s206,w202,w302,w303
 gztarticle.cls e300,s103,s204,s205,s206,w202,w302,w303
-hobby.code.tex s204,s206,w303
+hobby.code.tex s103,s204,s206,w303
 hobete.sty s103,s204,s205,s206
 hvarabic.sty s204
 hvfloat.sty s204,s206
@@ -264,9 +264,6 @@ mercatormap.sty s103,s204,s205,s206,w200,w302
 metrix.sty s103,s204,s205,w202
 mhchem.sty s103,s204,s205,s206,w302,w303
 minibox.sty s204
-minimalist.sty s204
-minimart.cls s103,s204
-minimbook.cls s103,s204
 mkpatter.tex s103,s204,w100,w200
 moderncv.cls s204,s206
 modiagram.sty s103,s204
@@ -482,7 +479,7 @@ xsim-manual.cls s103,s204
 xsim.sty s103,s204,s206,w200,w202
 xsim.style.schule-tabelle-kurz.code.tex s204
 xsimverb.sty s103,s204
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 zhlipsum.sty s204,s205,s206,w202,w302
 zhnumber.sty s103,s204,w200,w202,w302

--- a/explcheck/testfiles/TL2021-issues.txt
+++ b/explcheck/testfiles/TL2021-issues.txt
@@ -191,7 +191,7 @@ handoutWithNotes.sty s103,s204
 hanzibox.sty s103,s204,w200,w202,w302
 hep-bibliography.sty s204
 hep-math.sty s204
-hobby.code.tex s204,s206,w303
+hobby.code.tex s103,s204,s206,w303
 hobete.sty s103,s204,s205,s206
 hpstatement-bg.inc.sty s103,s204
 hpstatement-cs.inc.sty s103,s204
@@ -344,7 +344,7 @@ mhchem.sty s103,s204,s205,s206,w302,w303
 minibox.sty s204
 minimalist-classical.sty s103,s204,s206
 minimalist-plain.sty s103,s204,s206,w303
-minimalist.sty s103,s204
+minimalist.sty s103
 minimart.cls s103,s204
 minimbook.cls s103,s204
 mkpatter.tex s103,s204,w100,w200
@@ -613,7 +613,7 @@ xsim-manual.cls s103,s204
 xsim.sty s103,s204,s206,w200,w202
 xsim.style.schule-tabelle-kurz.code.tex s204
 xsimverb.sty s103,s204
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 zhlipsum.sty s204,s205,s206,w202,w302
 zhnumber.sty s103,s204,w200,w202,w302

--- a/explcheck/testfiles/TL2021-issues.txt
+++ b/explcheck/testfiles/TL2021-issues.txt
@@ -242,7 +242,7 @@ kantlipsum.sty s204,w200,w202
 keyparse.sty s204,w101
 knowledge.sty s103,s204,s205,s206,w101,w202
 kvmap.sty s103,s204
-l3benchmark.sty s103,s204,s205,w302
+l3benchmark.sty s103,s204,s205,w202,w302
 l3bitset.sty s103,w200
 l3doc.cls s204,s206,w200,w303
 l3draw.sty s103,s204,w202,w302

--- a/explcheck/testfiles/TL2022-issues.txt
+++ b/explcheck/testfiles/TL2022-issues.txt
@@ -232,7 +232,7 @@ hanzibox.sty s103,s204,w200,w202,w302
 hep-bibliography.sty s204
 hep-math.sty s204
 hfutexam.cls s204
-hobby.code.tex s204,s206,w303
+hobby.code.tex s103,s204,s206,w303
 hobete.sty s103,s204,s205,s206
 hpstatement-bg.inc.sty s103,s204
 hpstatement-cs.inc.sty s103,s204
@@ -467,7 +467,7 @@ pgfmath-xfp.sty s103,s204,w302
 phonenumbers.sty s103,s204
 phy-diagmat.sty s103,s204
 phy-xmat.sty s204
-piton.sty s204,s205,w302
+piton.sty e102,s103
 pkgloader-error.sty s204
 pkgloader.sty s103,s204,s206
 placeat.sty s204
@@ -666,7 +666,6 @@ uantwerpenletter.cls s103,s204,s206
 uantwerpenphdthesis.cls s204,s206
 uantwerpenreport.cls s204
 udes-genie-these.cls s103,s204,s205,s206,w202
-ufrgscca.cls s103,s204
 unicode-math-luatex.sty s204,s205,s206,w200,w202,w302,w303
 unicode-math-xetex.sty s204,s205,s206,w200,w202,w302,w303
 unicode-math.sty s204
@@ -725,7 +724,7 @@ xsim-manual.cls s103,s204
 xsim.sty s103,s204,s206,w200,w202
 xsim.style.schule-tabelle-kurz.code.tex s204
 xsimverb.sty s103,s204
-xtemplate.sty s204,s206,w302
+xtemplate.sty s103,s204,s206,w302
 xunicode-addon.sty s204,w200,w302,w303
 yathesis.cls s204
 zennote.sty s103,s204

--- a/explcheck/testfiles/TL2022-issues.txt
+++ b/explcheck/testfiles/TL2022-issues.txt
@@ -289,7 +289,7 @@ kfupm-math-exam.cls s204,s206
 knowledge.sty s103,s204,s205,s206,w101,w202
 koma-script-source-doc.cls s204
 kvmap.sty s103,s204
-l3benchmark.sty s103,s204,s205,w302
+l3benchmark.sty s103,s204,s205,w202,w302
 l3bitset.sty s103,w200
 l3doc.cls s204,s206,w200,w303
 l3draw.sty s103,s204,w202,w302

--- a/explcheck/testfiles/TL2023-issues.txt
+++ b/explcheck/testfiles/TL2023-issues.txt
@@ -329,7 +329,7 @@ kfupm-math-exam.cls s204,s206
 knowledge.sty s103,s204,s205,s206,w101,w202
 koma-script-source-doc.cls s204
 kvmap.sty s103,s204
-l3benchmark.sty s103,s204,s205,w302
+l3benchmark.sty s103,s204,s205,w202,w302
 l3doc.cls s204,s206,w200
 l3draw.sty s103,s204,w302
 l3galley.sty s103,s205,w200,w302

--- a/explcheck/testfiles/TL2024-issues.txt
+++ b/explcheck/testfiles/TL2024-issues.txt
@@ -387,7 +387,7 @@ kfupm-math-exam.cls s204,s206
 knowledge.sty s103,s204,s205,s206,w101,w202
 koma-script-source-doc.cls s204
 kvmap.sty s103,s204
-l3benchmark.sty s103,s204,s205,w302
+l3benchmark.sty s103,s204,s205,w202,w302
 l3doc.cls s204,s206,w200
 l3draw.sty s103,s204,w302
 l3galley.sty s103,s205,w200,w302

--- a/explcheck/testfiles/TL2024-issues.txt
+++ b/explcheck/testfiles/TL2024-issues.txt
@@ -679,7 +679,7 @@ regexpatch.sty s103,s204,w200,w202,w302
 rescansync.sty s103,s204,s205,s206
 responsive.sty e300,s103,s204,s205,s206,w302
 returntogrid.sty s103,s204,w303
-robust-externalize.sty s103,s204,s205,s206,w202,w303
+robust-externalize.sty e102,s103
 romande.sty s204
 rpgicons-l3.sty s103,s204,w303
 rpgicons-pgf.sty s204


### PR DESCRIPTION
This PR makes the following changes:

- Add a script `prune-explcheck-config.lua` that continuously checks for needless options in the configuration.
- Remove needless options from the default config file `explcheck-config.toml`.
- Update `CHANGES.md`.

This PR also makes the following unrelated changes:

- Run CI every Monday morning, after the weekly TeX Live Docker image has released.
- Include the date of generation and the latest obsolete entry in `explcheck-obsolete.lua`.