### PR TITLE
Switch to `softprops/action-gh-release` action for release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,12 +259,12 @@ jobs:
         with:
           merge-multiple: true
       - name: Publish prerelease
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@v2
         with:
-          title: The latest version
-          automatic_release_tag: latest
+          name: The latest version
+          tag_name: latest
           prerelease: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             expltools-ctan.zip
             *.pdf


### PR DESCRIPTION
When checking the Actions job runs in this repo, I noticed [two warnings](https://github.com/Witiko/expltools/actions/runs/14834059022/job/41641876056) (`` The `set-output` command is deprecated and will be disabled soon. ``) and finally found that the cause of them, [`marvinpinto/action-automatic-releases` action](https://github.com/marvinpinto/action-automatic-releases) is no longer maintained and its repository has been archived on May 6, 2024.

The author of `marvinpinto/action-automatic-releases` mentioned two alternatives in https://github.com/marvinpinto/actions/commit/40312c52f0ca0d0589b25e8f5172a3613f0759c3 and this PR picks the second one.

- https://github.com/semantic-release/github
- https://github.com/softprops/action-gh-release

Links to Action inputs
- old, `marvinpinto/action-automatic-releases`
  https://github.com/marvinpinto/action-automatic-releases?tab=readme-ov-file#supported-parameters
- new, `softprops/action-gh-release`
  https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs