### PR TITLE
In the CLI, do not consider arguments starting with `-` filenames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## expltools 2025-05-XX
 
+#### Fixes
+
+- In the command-line interface, do not consider arguments starting with `-`
+  filenames. (reported by @muzimuzhi in #83, fixed in #84)
+
 #### Continuous integration
 
 - Switch to the GitHub Action `softprops/action-gh-release` for automatic

--- a/explcheck/src/explcheck-cli.lua
+++ b/explcheck/src/explcheck-cli.lua
@@ -204,8 +204,8 @@ else
       options.verbose = true
     elseif argument == "--warnings-are-errors" then
       options.warnings_are_errors = true
-    elseif argument:sub(1, 2) == "--" then
-      -- An unknown argument
+    elseif argument:sub(1, 1) == "-" then
+      print(string.format('Unrecognized argument: %s\n', argument))
       print_usage()
       os.exit(1)
     else


### PR DESCRIPTION
This PR makes the following changes:

- In the CLI, do not consider arguments starting with `-` filenames.

Closes #83.