### PR TITLE
Improve workflows for forked repositories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,11 +229,13 @@ jobs:
             l3build
       - name: Install file "l3obsolete.txt"
         run: tlmgr install --reinstall --with-doc l3kernel
+      - name: Determine Docker image tag
+        run: printf 'IMAGE_TAG=ghcr.io/%s/explcheck\n' "$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and publish Docker image
         run: |
           set -e
           l3build tag
-          docker build -f explcheck/Dockerfile -t ghcr.io/${{ github.repository }}/explcheck .
+          docker build -f explcheck/Dockerfile -t ${{ env.IMAGE_TAG }} .
       - name: Login to GitHub Packages
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
@@ -243,7 +245,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Docker image
         if: github.ref == 'refs/heads/main'
-        run: docker push ghcr.io/${{ github.repository }}/explcheck
+        run: docker push ${{ env.IMAGE_TAG }}
   prerelease:
     name: Publish prerelease
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,7 +235,7 @@ jobs:
         run: |
           set -e
           l3build tag
-          docker build -f explcheck/Dockerfile -t ghcr.io/witiko/expltools/explcheck .
+          docker build -f explcheck/Dockerfile -t ghcr.io/${{ github.repository }}/explcheck .
       - name: Login to GitHub Packages
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
@@ -245,7 +245,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Docker image
         if: github.ref == 'refs/heads/main'
-        run: docker push ghcr.io/witiko/expltools/explcheck
+        run: docker push ghcr.io/${{ github.repository }}/explcheck
   prerelease:
     name: Publish prerelease
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Build and release
 on:
   push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
   schedule:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,13 @@
 - Switch to the GitHub Action `softprops/action-gh-release` for automatic
   pre-releases. (added by @muzimuzhi in #82)
 
+- Improve workflows for forked repositories.
+  (reported by @muzimuzhi in #85, fixed in #87)
+
+  Specifically, the name of the built docker image is now parametrized with
+  `${{ github.repository }}` and the primary workflow now runs on push to any
+  Git branch, not just the main branch.
+
 ### explcheck v0.10.0
 
 ## expltools 2025-05-05


### PR DESCRIPTION
This PR makes the following changes:

- Build Docker image `ghcr.io/${{ github.repository }}/explcheck` to better support forked repositories.
- Run the CI on push for all Git branches.

Closes #85.