### PR TITLE
Specify syntax highlighting for configs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# override the syntax highlighting used on GitHub.com
+# https://github.com/github-linguist/linguist/blob/main/docs/overrides.md
+.explcheckrc linguist-language=toml
+latexmkrc linguist-language=perl


### PR DESCRIPTION
This PR specifies/overrides the syntax highlighting language(s) used on GitHub.com for config files `.explcheckrc` and `latexmkrc`.

| | Before | After |
|--------|--------|--------|
| `.explcheckrc` | [no highlighting](https://github.com/Witiko/expltools/blob/50d01661a6d0e2e2ea9c21a3f8e2db14c7aac9ce/.explcheckrc) | [TOML highlighting](https://github.com/muzimuzhi/expltools/blob/980b9dee56bc93069348513f4bbe527f720f418b/.explcheckrc) |
| `latexmkrc` | [little highlighting](https://github.com/Witiko/expltools/blob/50d01661a6d0e2e2ea9c21a3f8e2db14c7aac9ce/explcheck/support/latexmkrc) | [Perl highlighting](https://github.com/muzimuzhi/expltools/blob/980b9dee56bc93069348513f4bbe527f720f418b/explcheck/support/latexmkrc) | 