### PR TITLE
Support flow analysis

### DIFF
--- a/.explcheckrc
+++ b/.explcheckrc
@@ -556,3 +556,6 @@ ignored_issues = ["e505"]
 
 [package.kantlipsum]
 ignored_issues = ["e505"]
+
+[package.novel]
+ignored_issues = ["e506"]

--- a/.explcheckrc
+++ b/.explcheckrc
@@ -453,7 +453,7 @@ ignored_issues = ["e201", "e304", "e411"]
 imported_prefixes = ["chemgreek"]
 
 [package.tabular2]
-ignored_issues = ["e405", "e411"]
+ignored_issues = ["e411"]
 
 [package.robust-externalize]
 ignored_issues = ["e304", "w423"]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,19 @@
 
 ### explcheck v0.19.0
 
+#### New features
+
+This version of explcheck has implemented the following new features:
+
+- Add more support for flow analysis. (#188)
+
+  This adds support for the following issues from Section 5.1 of the document
+  titled [_Warnings and errors for the expl3 analysis tool_][warnings-and-errors]:
+
+   1. E500 (Multiply defined function)
+
+#### Continuous integration
+
 This version of explcheck has made the following changes to our continuous
 integration:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ This version of explcheck has implemented the following new features:
 
    1. E500 (Multiply defined function)
    2. W501 (Multiply defined function variant)
+   3. E504 (Function variant for an undefined function)
 
 #### Continuous integration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ This version of explcheck has implemented the following new features:
   titled [_Warnings and errors for the expl3 analysis tool_][warnings-and-errors]:
 
    1. E500 (Multiply defined function)
+   2. W501 (Multiply defined function variant)
 
 #### Continuous integration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ This version of explcheck has implemented the following new features:
    2. W501 (Multiply defined function variant)
    3. E504 (Function variant for an undefined function)
    4. E506 (Indirect function definition from an undefined function)
+   5. W507 (Setting a function before definition)
 
 #### Continuous integration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ This version of explcheck has implemented the following new features:
    1. E500 (Multiply defined function)
    2. W501 (Multiply defined function variant)
    3. E504 (Function variant for an undefined function)
+   4. E506 (Indirect function definition from an undefined function)
 
 #### Continuous integration
 

--- a/explcheck/doc/e500-01.tex
+++ b/explcheck/doc/e500-01.tex
@@ -1,6 +1,1 @@
-\cs_new:Nn
-  \module_foo:
-  { bar }
-\cs_new:Nn  % error on this line
-  \module_foo:
-  { bar }
+../testfiles/e500-01.tex

--- a/explcheck/doc/e500-02.tex
+++ b/explcheck/doc/e500-02.tex
@@ -1,8 +1,1 @@
-\cs_new:Nn
-  \module_foo:
-  { bar }
-\cs_undefine:N
-  \module_foo:
-\cs_new:Nn
-  \module_foo:
-  { bar }
+../testfiles/e500-02.tex

--- a/explcheck/doc/e500-03.tex
+++ b/explcheck/doc/e500-03.tex
@@ -1,6 +1,1 @@
-\cs_new:Nn
-  \module_foo:
-  { bar }
-\cs_gset:Nn
-  \module_foo:
-  { bar }
+../testfiles/e500-03.tex

--- a/explcheck/doc/e500-04.tex
+++ b/explcheck/doc/e500-04.tex
@@ -1,8 +1,1 @@
-\prg_new_conditional:Nnn
-  \module_foo:
-  { p, T, F, TF }
-  { \prg_return_true: }
-\prg_new_conditional:Nnn  % error on this line
-  \module_foo:
-  { p, T, F, TF }
-  { \prg_return_true: }
+../testfiles/e500-04.tex

--- a/explcheck/doc/e500-05.tex
+++ b/explcheck/doc/e500-05.tex
@@ -1,16 +1,1 @@
-\prg_new_conditional:Nnn
-  \module_foo:
-  { p, T, F, TF }
-  { \prg_return_true: }
-\cs_undefine:N
-  \module_foo_p:
-\cs_undefine:N
-  \module_foo:T
-\cs_undefine:N
-  \module_foo:F
-\cs_undefine:N
-  \module_foo:TF
-\prg_new_conditional:Nnn
-  \module_foo:
-  { p, T, F, TF }
-  { \prg_return_true: }
+../testfiles/e500-05.tex

--- a/explcheck/doc/e500-06.tex
+++ b/explcheck/doc/e500-06.tex
@@ -1,8 +1,1 @@
-\prg_new_conditional:Nnn
-  \module_foo:
-  { p, T, F, TF }
-  { \prg_return_true: }
-\prg_gset_conditional:Nnn
-  \module_foo:
-  { p, T, F, TF }
-  { \prg_return_true: }
+../testfiles/e500-06.tex

--- a/explcheck/doc/e504-01.tex
+++ b/explcheck/doc/e504-01.tex
@@ -1,6 +1,1 @@
-\cs_new:Nn
-  \module_foo:n
-  { bar }
-\cs_generate_variant:Nn
-  \module_foo:n
-  { V }
+../testfiles/e504-01.tex

--- a/explcheck/doc/e504-02.tex
+++ b/explcheck/doc/e504-02.tex
@@ -1,6 +1,1 @@
-\cs_generate_variant:Nn  % error on this line
-  \module_foo:n
-  { V }
-\cs_new:Nn
-  \module_foo:n
-  { bar }
+../testfiles/e504-02.tex

--- a/explcheck/doc/e504-03.tex
+++ b/explcheck/doc/e504-03.tex
@@ -1,8 +1,1 @@
-\cs_new:Nn
-  \module_foo:n
-  { bar }
-\cs_undefine:N
-  \module_foo:n
-\cs_generate_variant:Nn  % error on this line
-  \module_foo:n
-  { V }
+../testfiles/e504-03.tex

--- a/explcheck/doc/e504-04.tex
+++ b/explcheck/doc/e504-04.tex
@@ -1,8 +1,1 @@
-\prg_new_conditional:Nnn
-  \module_foo:n
-  { p, T, F, TF }
-  { \prg_return_true: }
-\prg_generate_conditional_variant:Nnn
-  \module_foo:n
-  { V }
-  { TF }
+../testfiles/e504-04.tex

--- a/explcheck/doc/e504-05.tex
+++ b/explcheck/doc/e504-05.tex
@@ -1,8 +1,1 @@
-\prg_generate_conditional_variant:Nnn  % error on this line
-  \module_foo:n
-  { V }
-  { TF }
-\prg_new_conditional:Nnn
-  \module_foo:n
-  { p, T, F, TF }
-  { \prg_return_true: }
+../testfiles/e504-05.tex

--- a/explcheck/doc/e504-06.tex
+++ b/explcheck/doc/e504-06.tex
@@ -1,10 +1,1 @@
-\prg_new_conditional:Nnn
-  \module_foo:n
-  { p, T, F, TF }
-  { \prg_return_true: }
-\cs_undefine:N
-  \module_foo:nTF
-\prg_generate_conditional_variant:Nnn  % error on this line
-  \module_foo:n
-  { V }
-  { TF }
+../testfiles/e504-06.tex

--- a/explcheck/doc/e506-01.tex
+++ b/explcheck/doc/e506-01.tex
@@ -1,11 +1,1 @@
-\cs_new:Nn
-  \module_foo:n
-  { bar~#1 }
-\cs_new_eq:NN  % error on this line
-  \module_baz:n
-  \module_bar:n
-\cs_new_eq:NN
-  \module_bar:n
-  \module_foo:n
-\module_baz:n
-  { foo }
+../testfiles/e506-01.tex

--- a/explcheck/doc/e506-02.tex
+++ b/explcheck/doc/e506-02.tex
@@ -1,13 +1,1 @@
-\cs_new:Nn
-  \module_foo:n
-  { bar~#1 }
-\cs_new_eq:NN
-  \module_bar:n
-  \module_foo:n
-\cs_undefine:N
-  \module_bar:n
-\cs_new_eq:NN  % error on this line
-  \module_baz:n
-  \module_bar:n
-\module_baz:n
-  { foo }
+../testfiles/e506-02.tex

--- a/explcheck/doc/e506-03.tex
+++ b/explcheck/doc/e506-03.tex
@@ -1,14 +1,1 @@
-\prg_new_conditional:Nnn
-  \module_foo:n
-  { p, T, F, TF }
-  { \prg_return_true: }
-\cs_new_eq:NN  % error on this line
-  \module_baz:nTF
-  \module_bar:nTF
-\cs_new_eq:NN
-  \module_bar:nTF
-  \module_foo:nTF
-\module_baz:nTF
-  { foo }
-  { bar }
-  { baz }
+../testfiles/e506-03.tex

--- a/explcheck/doc/e506-04.tex
+++ b/explcheck/doc/e506-04.tex
@@ -1,16 +1,1 @@
-\prg_new_conditional:Nnn
-  \module_foo:n
-  { p, T, F, TF }
-  { \prg_return_true: }
-\cs_new_eq:NN
-  \module_bar:nTF
-  \module_foo:nTF
-\cs_undefine:N
-  \module_bar:nTF
-\cs_new_eq:NN  % error on this line
-  \module_baz:nTF
-  \module_bar:nTF
-\module_baz:nTF
-  { foo }
-  { bar }
-  { baz }
+../testfiles/e506-04.tex

--- a/explcheck/doc/w501-01.tex
+++ b/explcheck/doc/w501-01.tex
@@ -1,9 +1,1 @@
-\cs_new:Nn
-  \module_foo:n
-  { bar~#1 }
-\cs_generate_variant:Nn
-  \module_foo:n
-  { V }
-\cs_generate_variant:Nn  % warning on this line
-  \module_foo:n
-  { o, V }
+../testfiles/w501-01.tex

--- a/explcheck/doc/w501-02.tex
+++ b/explcheck/doc/w501-02.tex
@@ -1,11 +1,1 @@
-\cs_new:Nn
-  \module_foo:n
-  { bar~#1 }
-\cs_generate_variant:Nn
-  \module_foo:n
-  { V }
-\cs_undefine:N
-  \module_foo:V
-\cs_generate_variant:Nn
-  \module_foo:n
-  { o, V }
+../testfiles/w501-02.tex

--- a/explcheck/doc/w501-03.tex
+++ b/explcheck/doc/w501-03.tex
@@ -1,12 +1,1 @@
-\prg_new_conditional:Nnn
-  \module_foo:n
-  { p, T, F, TF }
-  { \prg_return_true: }
-\prg_generate_conditional_variant:Nnn
-  \module_foo:n
-  { V }
-  { TF }
-\prg_generate_conditional_variant:Nnn  % warning on this line
-  \module_foo:n
-  { o, V }
-  { TF }
+../testfiles/w501-03.tex

--- a/explcheck/doc/w501-04.tex
+++ b/explcheck/doc/w501-04.tex
@@ -1,14 +1,1 @@
-\prg_new_conditional:Nnn
-  \module_foo:n
-  { p, T, F, TF }
-  { \prg_return_true: }
-\prg_generate_conditional_variant:Nnn
-  \module_foo:n
-  { V }
-  { TF }
-\cs_undefine:N
-  \module_foo:VTF
-\prg_generate_conditional_variant:Nnn
-  \module_foo:n
-  { o, V }
-  { TF }
+../testfiles/w501-04.tex

--- a/explcheck/doc/w507-01.tex
+++ b/explcheck/doc/w507-01.tex
@@ -1,6 +1,1 @@
-\cs_gset:N  % warning on this line
-  \module_foo:
-  { foo }
-\cs_new:Nn
-  \module_foo:
-  { bar }
+../testfiles/w507-01.tex

--- a/explcheck/doc/w507-02.tex
+++ b/explcheck/doc/w507-02.tex
@@ -1,8 +1,1 @@
-\cs_new:Nn
-  \module_foo:
-  { bar }
-\cs_undefine:N
-  \module_foo:
-\cs_gset:N  % warning on this line
-  \module_foo:
-  { foo }
+../testfiles/w507-02.tex

--- a/explcheck/doc/warnings-and-errors-05-flow-analysis.md
+++ b/explcheck/doc/warnings-and-errors-05-flow-analysis.md
@@ -52,7 +52,7 @@ A private function or conditional function variant is defined but unused.
 
 This check is a stronger version of <#unused-private-function-variant> and the issue should only be emitted if <#unused-private-function-variant> has not previously been emitted for this function variant.
 
-### Function variant for an undefined function {.e label=e505}
+### Function variant for an undefined function {.e label=e504}
 A function or conditional function variant is defined before the base function has been defined or after it has been undefined.
 
  /e504-01.tex
@@ -61,18 +61,6 @@ A function or conditional function variant is defined before the base function h
  /e504-04.tex
  /e504-05.tex
  /e504-06.tex
-
-<!--
-
-  As with all the previous issues, we can't report this issue from the
-  `FUNCTION_CALL` edges alone.
-
-  Instead, we will need to report this issue either inside the inner loop
-  of reaching definitions whenever we are processing a function variant
-  definition statement or after the outer loop at the end of the function
-  `draw_group_wide_dynamic_edges()`.
-
--->
 
 This check is a stronger version of <#function-variant-for-undefined-function> and the issue should only be emitted if <#function-variant-for-undefined-function> has not previously been emitted for this function variant.
 
@@ -85,7 +73,7 @@ A function or conditional function (variant) is called before it has been define
 
 This check is a stronger version of <#calling-undefined-function> and the issue should only be emitted if <#calling-undefined-function> has not previously been emitted for this function.
 
-### Indirect function definition from an undefined function {.e}
+### Indirect function definition from an undefined function {.e label=e506}
 A function or conditional function is indirectly defined from a function that has yet to be defined or after it has been undefined.
 
  /e506-01.tex
@@ -93,25 +81,13 @@ A function or conditional function is indirectly defined from a function that ha
  /e506-03.tex
  /e506-04.tex
 
-<!--
-
-  The same considerations apply as for the issue E504.
-
--->
-
 This check is a stronger version of <#indirect-function-definition-from-undefined-function> and the issue should only be emitted if <#indirect-function-definition-from-undefined-function> has not previously been emitted for this function.
 
-### Setting a function before definition {.w}
+### Setting a function before definition {.w label=w507}
 A function is set before it has been defined or after it has been undefined.
 
  /w507-01.tex
  /w507-02.tex
-
-<!--
-
-  The same considerations apply as for the issues E504 and E506.
-
--->
 
 ### Unexpandable or restricted-expandable boolean expression {.e}
 A boolean expression [@latexteam2024interfaces, Section 9.2] is not fully-expandable.

--- a/explcheck/doc/warnings-and-errors-05-flow-analysis.md
+++ b/explcheck/doc/warnings-and-errors-05-flow-analysis.md
@@ -3,7 +3,7 @@ In the flow analysis step, the expl3 analysis tool determines compiler-theoretic
 
 ## Functions and conditional functions
 
-### Multiply defined function {.e}
+### Multiply defined function {.e label=e500}
 A function or conditional function is defined multiple times.
 
  /e500-01.tex
@@ -13,7 +13,7 @@ A function or conditional function is defined multiple times.
  /e500-05.tex
  /e500-06.tex
 
-### Multiply defined function variant {.w}
+### Multiply defined function variant {.w label=w501}
 A function or conditional function variant is defined multiple times.
 
  /w501-01.tex
@@ -76,7 +76,7 @@ A function or conditional function variant is defined before the base function h
 
 This check is a stronger version of <#function-variant-for-undefined-function> and the issue should only be emitted if <#function-variant-for-undefined-function> has not previously been emitted for this function variant.
 
-### Calling an undefined function {.e}
+### Calling an undefined function {.e label=e505}
 A function or conditional function (variant) is called before it has been defined or after it has been undefined.
 
  /e505-01.tex

--- a/explcheck/doc/warnings-and-errors-05-flow-analysis.md
+++ b/explcheck/doc/warnings-and-errors-05-flow-analysis.md
@@ -13,20 +13,6 @@ A function or conditional function is defined multiple times.
  /e500-05.tex
  /e500-06.tex
 
-<!--
-
-  We can't really report this issue from the `FUNCTION_CALL` edges alone.
-
-  Instead, we will need to report this issue either inside the inner loop
-  of reaching definitions whenever we are processing a function definition
-  statement or after the outer loop at the end of the function
-  `draw_group_wide_dynamic_edges()`.
-
-  We need to take into account the `maybe_redefinition` attribute of
-  `FUNCTION_DEFINITION` statements to differentiate between `new` and `set`.
-
--->
-
 ### Multiply defined function variant {.w}
 A function or conditional function variant is defined multiple times.
 
@@ -34,12 +20,6 @@ A function or conditional function variant is defined multiple times.
  /w501-02.tex
  /w501-03.tex
  /w501-04.tex
-
-<!--
-
-  The same considerations apply as for the previous issue (E500).
-
--->
 
 ### Unused private function {.w}
 A private function or conditional function is defined but unused.

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -504,9 +504,10 @@ local function any_edges_changed(first_edges, second_edges)
 end
 
 -- Index an edge in an edge index.
-local function _index_edge(states, edge_index, index_key, edge)
+local function _index_edge(states, edge_index_name, index_key, edge)
   assert(not states[edge.from.chunk.segment.location.file_number].results.stopped_early)
   assert(not states[edge.to.chunk.segment.location.file_number].results.stopped_early)
+  local edge_index = states.results.edge_indexes[edge_index_name]
   local chunk, statement_number = edge[index_key].chunk, edge[index_key].statement_number
   if edge_index[chunk] == nil then
     edge_index[chunk] = {}
@@ -620,10 +621,16 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     -- Run reaching definitions, see <https://en.wikipedia.org/wiki/Reaching_definition#Worklist_algorithm>.
     --
     -- First of, we will track the reaching definitions themselves.
-    local reaching_definition_lists, reaching_definition_indexes = {}, {}
+    states.results.reaching_definitions = {
+      lists = {},
+      indexes = {},
+    }
 
     -- Index all explicit "static" and currently estimated "dynamic" incoming and outgoing edges for each statement.
-    local explicit_in_edge_index, explicit_out_edge_index = {}, {}
+    states.results.edge_indexes = {
+      explicit_in = {},
+      explicit_out = {},
+    }
     local edge_lists = {current_function_call_edges}
     for _, state in ipairs(states) do
       local edge_category_list = {}
@@ -639,8 +646,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     end
     for _, edges in ipairs(edge_lists) do
       for _, edge in ipairs(edges) do
-        index_edge(explicit_in_edge_index, 'to', edge)
-        index_edge(explicit_out_edge_index, 'from', edge)
+        index_edge('explicit_in', 'to', edge)
+        index_edge('explicit_out', 'from', edge)
       end
     end
 
@@ -652,8 +659,10 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         return true
       end
       -- (Pseudo-)statements with incoming or outgoing explicit edges are interesting.
-      if explicit_in_edge_index[chunk] ~= nil and explicit_in_edge_index[chunk][statement_number] ~= nil
-          or explicit_out_edge_index[chunk] ~= nil and explicit_out_edge_index[chunk][statement_number] ~= nil then
+      if states.results.edge_indexes.explicit_in[chunk] ~= nil and
+            states.results.edge_indexes.explicit_in[chunk][statement_number] ~= nil or
+          states.results.edge_indexes.explicit_out[chunk] ~= nil and
+            states.results.edge_indexes.explicit_out[chunk][statement_number] ~= nil then
         return true
       end
       -- Well-behaved statements are interesting.
@@ -683,7 +692,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     end
 
     -- Index all implicit incoming and outgoing pseudo-edges as well.
-    local implicit_in_edge_index, implicit_out_edge_index = {}, {}
+    states.results.edge_indexes.implicit_in, states.results.edge_indexes.implicit_out = {}, {}
     for _, state in ipairs(states) do
       -- Skip statements from files in the current file group that haven't reached the flow analysis.
       if state.results.stopped_early then
@@ -710,8 +719,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                 },
                 confidence = edge_confidence,
               }
-              index_edge(implicit_in_edge_index, 'to', edge)
-              index_edge(implicit_out_edge_index, 'from', edge)
+              index_edge('implicit_in', 'to', edge)
+              index_edge('implicit_out', 'from', edge)
             end
             previous_interesting_statement_number = statement_number
             edge_confidence = DEFINITELY
@@ -729,8 +738,9 @@ local function draw_group_wide_dynamic_edges(states, _, options)
               end
 
               local has_t_branch, has_f_branch = false, false
-              if explicit_out_edge_index[chunk] ~= nil and explicit_out_edge_index[chunk][statement_number] ~= nil then
-                for _, edge in ipairs(explicit_out_edge_index[chunk][statement_number]) do
+              if states.results.edge_indexes.explicit_out[chunk] ~= nil and
+                  states.results.edge_indexes.explicit_out[chunk][statement_number] ~= nil then
+                for _, edge in ipairs(states.results.edge_indexes.explicit_out[chunk][statement_number]) do
                   -- For fully-resolved function calls, cancel the implicit pseudo-edge towards the next interesting statement;
                   -- instead, the reaching definitions will be routed through the replacement text of the function, at whose end
                   -- we'll return to the (interesting) statement following the function call.
@@ -772,13 +782,14 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         local original_incoming_definition_list, original_incoming_definition_index = {}, {}
         local original_incoming_definition_edge_confidence_lists = {}
         local in_degree = 0
-        for _, in_edge_index in ipairs({explicit_in_edge_index, implicit_in_edge_index}) do
+        for _, in_edge_index in ipairs({states.results.edge_indexes.explicit_in, states.results.edge_indexes.implicit_in}) do
           if in_edge_index[chunk] ~= nil and in_edge_index[chunk][statement_number] ~= nil then
             for _, edge in ipairs(in_edge_index[chunk][statement_number]) do
-              if reaching_definition_lists[edge.from.chunk] ~= nil and
-                  reaching_definition_lists[edge.from.chunk][edge.from.statement_number] ~= nil then
+              if states.results.reaching_definitions.lists[edge.from.chunk] ~= nil and
+                  states.results.reaching_definitions.lists[edge.from.chunk][edge.from.statement_number] ~= nil then
                 in_degree = in_degree + 1
-                local reaching_definition_list = reaching_definition_lists[edge.from.chunk][edge.from.statement_number]
+                local reaching_definition_list
+                  = states.results.reaching_definitions.lists[edge.from.chunk][edge.from.statement_number]
                 for _, definition in ipairs(reaching_definition_list) do
                   -- Record the different incoming definitions together with the corresponding edge confidences.
                   if original_incoming_definition_index[definition] == nil then
@@ -988,13 +999,13 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     -- Determine whether the reaching definitions after the current statement have changed.
     local function have_reaching_definitions_changed(chunk, statement_number, updated_definition_list, current_reaching_statement_index)
       -- Determine the previous set of definitions, if any.
-      if reaching_definition_lists[chunk] == nil then
+      if states.results.reaching_definitions.lists[chunk] == nil then
         return true
       end
-      if reaching_definition_lists[chunk][statement_number] == nil then
+      if states.results.reaching_definitions.lists[chunk][statement_number] == nil then
         return true
       end
-      local previous_definition_list = reaching_definition_lists[chunk][statement_number]
+      local previous_definition_list = states.results.reaching_definitions.lists[chunk][statement_number]
       assert(previous_definition_list ~= nil)
       assert(#previous_definition_list <= #updated_definition_list)
 
@@ -1110,7 +1121,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       -- Update the stack of changed statements.
       if have_reaching_definitions_changed(chunk, statement_number, updated_definition_list, current_reaching_statement_index) then
         -- Insert the successive statements into the stack of changed statements.
-        for _, out_edge_index in ipairs({explicit_out_edge_index, implicit_out_edge_index}) do
+        for _, out_edge_index in ipairs({states.results.edge_indexes.explicit_out, states.results.edge_indexes.implicit_out}) do
           if out_edge_index[chunk] ~= nil and out_edge_index[chunk][statement_number] ~= nil then
             for _, edge in ipairs(out_edge_index[chunk][statement_number]) do
               add_changed_statement(edge.to.chunk, edge.to.statement_number)
@@ -1119,18 +1130,18 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         end
 
         -- Update the reaching definitions.
-        if reaching_definition_lists[chunk] == nil then
-          assert(reaching_definition_indexes[chunk] == nil)
-          reaching_definition_lists[chunk] = {}
-          reaching_definition_indexes[chunk] = {}
+        if states.results.reaching_definitions.lists[chunk] == nil then
+          assert(states.results.reaching_definitions.indexes[chunk] == nil)
+          states.results.reaching_definitions.lists[chunk] = {}
+          states.results.reaching_definitions.indexes[chunk] = {}
         end
-        if reaching_definition_lists[chunk][statement_number] == nil then
-          assert(reaching_definition_indexes[chunk][statement_number] == nil)
-          reaching_definition_lists[chunk][statement_number] = {}
-          reaching_definition_indexes[chunk][statement_number] = {}
+        if states.results.reaching_definitions.lists[chunk][statement_number] == nil then
+          assert(states.results.reaching_definitions.indexes[chunk][statement_number] == nil)
+          states.results.reaching_definitions.lists[chunk][statement_number] = {}
+          states.results.reaching_definitions.indexes[chunk][statement_number] = {}
         end
-        reaching_definition_lists[chunk][statement_number] = updated_definition_list
-        reaching_definition_indexes[chunk][statement_number] = updated_definition_index
+        states.results.reaching_definitions.lists[chunk][statement_number] = updated_definition_list
+        states.results.reaching_definitions.indexes[chunk][statement_number] = updated_definition_index
       end
 
       inner_loop_number = inner_loop_number + 1
@@ -1147,14 +1158,14 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     for _, function_call_chunk_and_statement_number in ipairs(function_call_list) do
       -- For each function call, first copy relevant reaching definitions to a temporary list.
       local function_call_chunk, function_call_statement_number = table.unpack(function_call_chunk_and_statement_number)
-      if reaching_definition_indexes[function_call_chunk] == nil or
-          reaching_definition_indexes[function_call_chunk][function_call_statement_number] == nil then
+      if states.results.reaching_definitions.indexes[function_call_chunk] == nil or
+          states.results.reaching_definitions.indexes[function_call_chunk][function_call_statement_number] == nil then
         goto next_function_call
       end
       local function_call_statement = get_statement(function_call_chunk, function_call_statement_number)
       assert(is_well_behaved(function_call_statement))
       local reaching_function_and_variant_definition_list = {}
-      local reaching_definition_index = reaching_definition_indexes[function_call_chunk][function_call_statement_number]
+      local reaching_definition_index = states.results.reaching_definitions.indexes[function_call_chunk][function_call_statement_number]
       local used_csname = function_call_statement.used_csname.payload
       for _, definition in ipairs(reaching_definition_index[used_csname] or {}) do
         assert(definition.csname == used_csname)
@@ -1182,8 +1193,9 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         elseif statement.type == FUNCTION_DEFINITION and statement.subtype == FUNCTION_DEFINITION_INDIRECT
             or statement.type == FUNCTION_VARIANT_DEFINITION then
           -- Resolve the indirect function definitions and function variant definitions.
-          if reaching_definition_lists[chunk] ~= nil and reaching_definition_lists[chunk][macro_statement_number] ~= nil then
-            local other_reaching_definition_index = reaching_definition_indexes[chunk][macro_statement_number]
+          if states.results.reaching_definitions.lists[chunk] ~= nil and
+              states.results.reaching_definitions.lists[chunk][macro_statement_number] ~= nil then
+            local other_reaching_definition_index = states.results.reaching_definitions.indexes[chunk][macro_statement_number]
             local base_csname = statement.base_csname.payload
             for _, other_definition in ipairs(other_reaching_definition_index[base_csname] or {}) do
               local other_chunk, other_macro_statement_number, other_statement_number
@@ -1483,10 +1495,10 @@ local function report_issues(states, main_file_number, _)
   end
 
   -- Collect a list of function call edges.
-  local function_call_edge_index = {}
+  states.results.edge_indexes.function_call = {}
   for _, edge in ipairs(results.edges[DYNAMIC] or {}) do
     if edge.type == FUNCTION_CALL then
-      index_edge(function_call_edge_index, 'from', edge)
+      index_edge('function_call', 'from', edge)
     end
   end
 
@@ -1514,16 +1526,24 @@ local function report_issues(states, main_file_number, _)
   -- Report calling an undefined function.
   for _, chunk_and_statement_number in ipairs(definite_function_call_list) do
     local chunk, statement_number = table.unpack(chunk_and_statement_number)
-    if function_call_edge_index[chunk] == nil or function_call_edge_index[chunk][statement_number] == nil then
+    if states.results.edge_indexes.function_call[chunk] == nil or
+        states.results.edge_indexes.function_call[chunk][statement_number] == nil then
       local statement = _get_statement(chunk, statement_number)
       local byte_range = statement_to_byte_range(chunk, statement_number)
       local csname = statement.used_csname
 
       issues:add("e505", "calling an undefined function", byte_range, format_csname(csname.transcript))
     else
-      assert(#function_call_edge_index[chunk][statement_number] > 0)
+      assert(#states.results.edge_indexes.function_call[chunk][statement_number] > 0)
     end
   end
+end
+
+-- Remove auxiliary intermediate results to free up memory.
+local function cleanup(states, _, _)
+  -- Remove group-wide intermediate results.
+  states.results.edge_indexes = nil
+  states.results.reaching_definitions = nil
 end
 
 local substeps = {
@@ -1533,6 +1553,7 @@ local substeps = {
   draw_group_wide_static_edges,
   draw_group_wide_dynamic_edges,
   report_issues,
+  cleanup,
 }
 
 return {

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -648,30 +648,6 @@ end
 -- Determine the definitions and undefinitions from the current statement.
 local function get_current_definitions(
     states, chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, max_statement_number)
-
-  local segment = chunk.segment
-  local file_number = segment.location.file_number
-  local state = states[file_number]
-
-  local issues = state.issues
-
-  -- Get the byte range of a regular (non-macro) statement.
-  local function statement_to_byte_range(statement_number)
-    local part_number = segment.location.part_number
-    local tokens = state.results.tokens[part_number]
-
-    local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
-    local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
-
-    local statement = get_statement(states, chunk, macro_statement_number, statement_number)
-    assert(not is_macro_statement(statement))
-
-    local token_range = call_range_to_token_range(statement.call_range)
-    local byte_range = token_range_to_byte_range(token_range)
-
-    return byte_range
-  end
-
   local current_definition_list, current_definition_index = {}, {}
   local invalidated_statement_index = {}
   if macro_statement_number <= chunk.statement_range:stop() then  -- Unless this is a pseudo-statement "after" a chunk.
@@ -733,23 +709,6 @@ local function get_current_definitions(
             )
             assert(incoming_statement.defined_csname.payload == defined_or_undefined_csname)
             if incoming_statement ~= statement and not invalidated_statement_index[incoming_statement] then
-              if incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition
-                  or incoming_statement.type == FUNCTION_VARIANT_DEFINITION then
-                if statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition
-                    or statement.type == FUNCTION_VARIANT_DEFINITION then
-                  local byte_range = statement_to_byte_range(statement_number)
-                  local formatted_csname = format_csname(defined_or_undefined_csname)
-                  -- Report a multiply defined function.
-                  if statement.type == FUNCTION_DEFINITION then
-                    issues:add("e500", "multiply defined function", byte_range, formatted_csname)
-                  -- Report a multiply defined function variant.
-                  elseif statement.type == FUNCTION_VARIANT_DEFINITION then
-                    issues:add("w501", "multiply defined function variant", byte_range, formatted_csname)
-                  else
-                    error('Unexpected statement type "' .. statement.type .. '"')
-                  end
-                end
-              end
               invalidated_statement_index[incoming_statement] = true
             end
           end
@@ -1387,19 +1346,60 @@ local function report_issues(states, main_file_number, options)
             end
 
             -- Determine whether there are any definite definitions for a given control sequence name that reach the current statement.
-            local function any_definite_reaching_definitions(csname)
-              if lpeg.match(expl3_well_known_csname, csname) ~= nil then
-                -- Always consider definitions for well-known expl3 control sequence names to be reaching.
-                return true
-              end
+            local function any_definite_reaching_definitions(csname, check_definition)
               for definition in get_reaching_definitions(csname) do
                 assert(definition.csname == csname)
                 assert(definition.macro_statement_number <= macro_statement_number)
                 if definition.macro_statement_number == macro_statement_number then
                   assert(definition.statement_number < statement_number)
                 end
-                if definition.confidence == DEFINITELY then
+                if definition.confidence ~= DEFINITELY then
+                  goto next_definition
+                end
+                if check_definition ~= nil then
+                  local other_statement = get_statement(
+                    states,
+                    definition.chunk,
+                    definition.macro_statement_number,
+                    definition.statement_number
+                  )
+                  if check_definition(definition, other_statement) then
+                    return true
+                  else
+                    goto next_definition
+                  end
+                else
                   return true
+                end
+                ::next_definition::
+              end
+            end
+
+            if (
+                  statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition or
+                  statement.type == FUNCTION_VARIANT_DEFINITION
+                ) and statement.defined_csname.type == TEXT then
+              local defined_csname = statement.defined_csname.payload
+              if any_definite_reaching_definitions(
+                    defined_csname,
+                    function(_, other_statement)
+                      return (
+                        other_statement.type == FUNCTION_DEFINITION and not other_statement.maybe_redefinition or
+                        other_statement.type == FUNCTION_VARIANT_DEFINITION
+                      )
+                    end
+                  ) then
+                local formatted_csname = format_csname(defined_csname)
+                local byte_range = get_byte_range()
+
+                -- Report a multiply defined function.
+                if statement.type == FUNCTION_DEFINITION then
+                  issues:add("e500", "multiply defined function", byte_range, formatted_csname)
+                -- Report a multiply defined function variant.
+                elseif statement.type == FUNCTION_VARIANT_DEFINITION then
+                  issues:add("w501", "multiply defined function variant", byte_range, formatted_csname)
+                else
+                  error('Unexpected statement type "' .. statement.type .. '"')
                 end
               end
             end
@@ -1409,7 +1409,8 @@ local function report_issues(states, main_file_number, options)
                   statement.type == FUNCTION_DEFINITION and statement.subtype == FUNCTION_DEFINITION_INDIRECT
                 ) and statement.base_csname.type == TEXT then
               local base_csname = statement.base_csname.payload
-              if not any_definite_reaching_definitions(base_csname) then
+              if lpeg.match(expl3_well_known_csname, base_csname) == nil and
+                  not any_definite_reaching_definitions(base_csname) then
                 local formatted_csname = format_csname(base_csname)
                 local byte_range = get_byte_range()
 
@@ -1432,7 +1433,8 @@ local function report_issues(states, main_file_number, options)
                 -- Ideally, we would consider all function calls that are reachable from top-level code.
                 and segment.nesting_depth == 1 then
               local defined_csname = statement.defined_csname.payload
-              if not any_definite_reaching_definitions(defined_csname) then
+              if lpeg.match(expl3_well_known_csname, defined_csname) == nil and
+                  not any_definite_reaching_definitions(defined_csname) then
                 local formatted_csname = format_csname(defined_csname)
                 local byte_range = get_byte_range()
                 issues:add("w507", "setting a function before definition", byte_range, formatted_csname)

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -988,9 +988,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                   incoming_definition.statement_number
                 )
                 assert(incoming_statement.defined_csname.payload == defined_or_undefined_csname)
-                if incoming_statement ~= statement then
-                  if invalidated_statement_index[incoming_statement] == nil and
-                      incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition and
+                if incoming_statement ~= statement and not invalidated_statement_index[incoming_statement] then
+                  if incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition and
                       statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition then
                     local byte_range = statement_to_byte_range(statement_number)
                     issues:add("e500", "multiply defined function", byte_range, format_csname(defined_or_undefined_csname))

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -536,6 +536,53 @@ local function is_well_behaved(statement)
   return result
 end
 
+-- Check whether a statement is "interesting". A statement is interesting if it has the potential to consume or affect
+-- the reaching definitions other than just passing along the definitions from the previous statement in the chunk.
+local function _is_interesting(states, chunk, macro_statement_number)
+
+  -- Resolve the chunk and statement number to a statement.
+  local function get_statement()
+    assert(not states[chunk.segment.location.file_number].results.stopped_early)
+    return _get_statement(chunk, macro_statement_number)
+  end
+
+  -- Chunk boundaries are interesting.
+  if macro_statement_number == chunk.statement_range:start() or macro_statement_number == chunk.statement_range:stop() + 1 then
+    return true
+  end
+  -- (Pseudo-)statements with incoming or outgoing explicit edges are interesting.
+  if states.results.edge_indexes.explicit_in[chunk] ~= nil and
+        states.results.edge_indexes.explicit_in[chunk][macro_statement_number] ~= nil or
+      states.results.edge_indexes.explicit_out[chunk] ~= nil and
+        states.results.edge_indexes.explicit_out[chunk][macro_statement_number] ~= nil then
+    return true
+  end
+  -- Well-behaved statements are interesting.
+  local macro_statement = get_statement()
+  if macro_statement.type == FUNCTION_CALL and is_well_behaved(macro_statement) then
+    return true
+  end
+  -- Macro-statements containing at least one interesting statement are interesting.
+  local any_well_behaved_statements = false
+  for _, statement in ipairs(macro_statement.statements or {macro_statement}) do
+    assert(not is_macro_statement(statement))
+    if (
+          statement.type == FUNCTION_DEFINITION or
+          statement.type == FUNCTION_UNDEFINITION or
+          statement.type == FUNCTION_VARIANT_DEFINITION
+        )
+        and is_well_behaved(statement) then
+      any_well_behaved_statements = true
+      goto skip_remaining_statements
+    end
+  end
+  ::skip_remaining_statements::
+  if any_well_behaved_statements then
+    return true
+  end
+  return false
+end
+
 -- Draw "dynamic" edges between chunks between all files in a file group. A dynamic edge requires estimation.
 local function draw_group_wide_dynamic_edges(states, _, options)
   -- Draw dynamic edges once between all files in the file group, not just individual files.
@@ -553,6 +600,12 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   local function get_statement(chunk, macro_statement_number, statement_number)
     assert(not states[chunk.segment.location.file_number].results.stopped_early)
     return _get_statement(chunk, macro_statement_number, statement_number)
+  end
+
+  -- Check whether a statement is "interesting". A statement is interesting if it has the potential to consume or affect
+  -- the reaching definitions other than just passing along the definitions from the previous statement in the chunk.
+  local function is_interesting(chunk, macro_statement_number)
+    return _is_interesting(states, chunk, macro_statement_number)
   end
 
   -- Collect a list of well-behaved function definition and call statements.
@@ -649,46 +702,6 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         index_edge('explicit_in', 'to', edge)
         index_edge('explicit_out', 'from', edge)
       end
-    end
-
-    -- Check whether a statement is "interesting". A statement is interesting if it has the potential to consume or affect
-    -- the reaching definitions other than just passing along the definitions from the previous statement in the chunk.
-    local function is_interesting(chunk, statement_number)
-      -- Chunk boundaries are interesting.
-      if statement_number == chunk.statement_range:start() or statement_number == chunk.statement_range:stop() + 1 then
-        return true
-      end
-      -- (Pseudo-)statements with incoming or outgoing explicit edges are interesting.
-      if states.results.edge_indexes.explicit_in[chunk] ~= nil and
-            states.results.edge_indexes.explicit_in[chunk][statement_number] ~= nil or
-          states.results.edge_indexes.explicit_out[chunk] ~= nil and
-            states.results.edge_indexes.explicit_out[chunk][statement_number] ~= nil then
-        return true
-      end
-      -- Well-behaved statements are interesting.
-      local macro_statement = get_statement(chunk, statement_number)
-      if macro_statement.type == FUNCTION_CALL and is_well_behaved(macro_statement) then
-        return true
-      end
-      -- Macro-statements containing at least one interesting statement are interesting.
-      local any_well_behaved_statements = false
-      for _, statement in ipairs(macro_statement.statements or {macro_statement}) do
-        assert(not is_macro_statement(statement))
-        if (
-              statement.type == FUNCTION_DEFINITION or
-              statement.type == FUNCTION_UNDEFINITION or
-              statement.type == FUNCTION_VARIANT_DEFINITION
-            )
-            and is_well_behaved(statement) then
-          any_well_behaved_statements = true
-          goto skip_remaining_statements
-        end
-      end
-      ::skip_remaining_statements::
-      if any_well_behaved_statements then
-        return true
-      end
-      return false
     end
 
     -- Index all implicit incoming and outgoing pseudo-edges as well.

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -521,7 +521,7 @@ local function is_well_behaved(statement)
   if statement.type == FUNCTION_CALL then
     result = statement.used_csname.type == TEXT
   elseif statement.type == FUNCTION_DEFINITION then
-    result = statement.defined_csname.type == TEXT and statement.maybe_used
+    result = statement.defined_csname.type == TEXT and (statement.maybe_used or statement.maybe_multiply_defined)
   elseif statement.type == FUNCTION_UNDEFINITION then
     result = statement.undefined_csname.type == TEXT and statement.maybe_used
   elseif statement.type == FUNCTION_VARIANT_DEFINITION then

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -525,7 +525,7 @@ local function is_well_behaved(statement)
   elseif statement.type == FUNCTION_UNDEFINITION then
     result = statement.undefined_csname.type == TEXT and (statement.maybe_used or statement.maybe_multiply_defined)
   elseif statement.type == FUNCTION_VARIANT_DEFINITION then
-    result = statement.defined_csname.type == TEXT and statement.maybe_used
+    result = statement.defined_csname.type == TEXT and (statement.maybe_used or statement.maybe_multiply_defined)
   else
     error('Unexpected statement type "' .. statement.type .. '"')
   end
@@ -989,10 +989,22 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                 )
                 assert(incoming_statement.defined_csname.payload == defined_or_undefined_csname)
                 if incoming_statement ~= statement and not invalidated_statement_index[incoming_statement] then
-                  if incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition and
-                      statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition then
-                    local byte_range = statement_to_byte_range(statement_number)
-                    issues:add("e500", "multiply defined function", byte_range, format_csname(defined_or_undefined_csname))
+                  if incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition
+                      or incoming_statement.type == FUNCTION_VARIANT_DEFINITION then
+                    if statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition
+                        or statement.type == FUNCTION_VARIANT_DEFINITION then
+                      local byte_range = statement_to_byte_range(statement_number)
+                      local formatted_csname = format_csname(defined_or_undefined_csname)
+                      -- Report a multiply defined function.
+                      if statement.type == FUNCTION_DEFINITION then
+                        issues:add("e500", "multiply defined function", byte_range, formatted_csname)
+                      -- Report a multiply defined function variant.
+                      elseif statement.type == FUNCTION_VARIANT_DEFINITION then
+                        issues:add("w501", "multiply defined function variant", byte_range, formatted_csname)
+                      else
+                        error('Unexpected statement type "' .. statement.type .. '"')
+                      end
+                    end
                   end
                   invalidated_statement_index[incoming_statement] = true
                 end

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -938,6 +938,46 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       return current_definition_list, invalidated_statement_index
     end
 
+    -- Determine the reaching definitions after the current statement.
+    local function get_outgoing_definitions(incoming_definition_list, current_definition_list, invalidated_statement_index)
+      local updated_definition_list, updated_definition_index = {}, {}
+      local current_reaching_statement_index = {}
+      for _, definition_list in ipairs({incoming_definition_list, current_definition_list}) do
+        for _, definition in ipairs(definition_list) do
+          local statement = get_statement(definition.chunk, definition.macro_statement_number, definition.statement_number)
+          assert(is_well_behaved(statement))
+          -- Skip invalidated definitions.
+          if invalidated_statement_index[statement] then
+            goto next_definition
+          end
+          -- Record the first occurrence of a definition.
+          if current_reaching_statement_index[statement] == nil then
+            table.insert(updated_definition_list, definition)
+            -- Also index the reaching definitions by defined control sequence names.
+            if updated_definition_index[definition.csname] == nil then
+              updated_definition_index[definition.csname] = {}
+            end
+            table.insert(updated_definition_index[definition.csname], definition)
+            current_reaching_statement_index[statement] = {
+              #updated_definition_list,
+              #updated_definition_index[definition.csname],
+            }
+          -- For repeated occurrences of a definition, keep the ones with the highest confidence.
+          else
+            local other_definition_list_number, other_definition_index_number = table.unpack(current_reaching_statement_index[statement])
+            -- If the current occurrence has a higher confidence, replace the previous occurrence with it.
+            local other_definition = updated_definition_list[other_definition_list_number]
+            if definition.confidence > other_definition.confidence then
+              updated_definition_list[other_definition_list_number] = definition
+              updated_definition_index[definition.csname][other_definition_index_number] = definition
+            end
+          end
+          ::next_definition::
+        end
+      end
+      return updated_definition_list, updated_definition_index, current_reaching_statement_index
+    end
+
     -- Determine whether the reaching definitions after the current statement have changed.
     local function have_reaching_definitions_changed(chunk, statement_number, updated_definition_list, current_reaching_statement_index)
       -- Determine the previous set of definitions, if any.
@@ -1057,41 +1097,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         = get_current_definitions(chunk, statement_number, incoming_definition_list, incoming_definition_index)
 
       -- Determine the reaching definitions after the current statement.
-      local updated_definition_list, updated_definition_index = {}, {}
-      local current_reaching_statement_index = {}
-      for _, definition_list in ipairs({incoming_definition_list, current_definition_list}) do
-        for _, definition in ipairs(definition_list) do
-          local statement = get_statement(definition.chunk, definition.macro_statement_number, definition.statement_number)
-          assert(is_well_behaved(statement))
-          -- Skip invalidated definitions.
-          if invalidated_statement_index[statement] then
-            goto next_definition
-          end
-          -- Record the first occurrence of a definition.
-          if current_reaching_statement_index[statement] == nil then
-            table.insert(updated_definition_list, definition)
-            -- Also index the reaching definitions by defined control sequence names.
-            if updated_definition_index[definition.csname] == nil then
-              updated_definition_index[definition.csname] = {}
-            end
-            table.insert(updated_definition_index[definition.csname], definition)
-            current_reaching_statement_index[statement] = {
-              #updated_definition_list,
-              #updated_definition_index[definition.csname],
-            }
-          -- For repeated occurrences of a definition, keep the ones with the highest confidence.
-          else
-            local other_definition_list_number, other_definition_index_number = table.unpack(current_reaching_statement_index[statement])
-            -- If the current occurrence has a higher confidence, replace the previous occurrence with it.
-            local other_definition = updated_definition_list[other_definition_list_number]
-            if definition.confidence > other_definition.confidence then
-              updated_definition_list[other_definition_list_number] = definition
-              updated_definition_index[definition.csname][other_definition_index_number] = definition
-            end
-          end
-          ::next_definition::
-        end
-      end
+      local updated_definition_list, updated_definition_index, current_reaching_statement_index
+        = get_outgoing_definitions(incoming_definition_list, current_definition_list, invalidated_statement_index)
 
       -- Update the stack of changed statements.
       if have_reaching_definitions_changed(chunk, statement_number, updated_definition_list, current_reaching_statement_index) then

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -762,6 +762,68 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       ::next_file::
     end
 
+    -- Determine the reaching definitions from before the current statement.
+    local function get_incoming_definitions(chunk, statement_number)
+      local incoming_definition_list, incoming_definition_index = {}, {}
+      do
+        local original_incoming_definition_list, original_incoming_definition_index = {}, {}
+        local original_incoming_definition_edge_confidence_lists = {}
+        local in_degree = 0
+        for _, in_edge_index in ipairs({explicit_in_edge_index, implicit_in_edge_index}) do
+          if in_edge_index[chunk] ~= nil and in_edge_index[chunk][statement_number] ~= nil then
+            for _, edge in ipairs(in_edge_index[chunk][statement_number]) do
+              if reaching_definition_lists[edge.from.chunk] ~= nil and
+                  reaching_definition_lists[edge.from.chunk][edge.from.statement_number] ~= nil then
+                in_degree = in_degree + 1
+                local reaching_definition_list = reaching_definition_lists[edge.from.chunk][edge.from.statement_number]
+                for _, definition in ipairs(reaching_definition_list) do
+                  -- Record the different incoming definitions together with the corresponding edge confidences.
+                  if original_incoming_definition_index[definition] == nil then
+                    assert(original_incoming_definition_edge_confidence_lists[definition] == nil)
+                    table.insert(original_incoming_definition_list, definition)
+                    original_incoming_definition_index[definition] = #original_incoming_definition_list
+                    table.insert(original_incoming_definition_edge_confidence_lists, {})
+                    assert(#original_incoming_definition_edge_confidence_lists == #original_incoming_definition_list)
+                  end
+                  local definition_number = original_incoming_definition_index[definition]
+                  table.insert(original_incoming_definition_edge_confidence_lists[definition_number], edge.confidence)
+                end
+              end
+            end
+          end
+        end
+        for definition_number, definition in ipairs(original_incoming_definition_list) do
+          local definition_edge_confidence_list = original_incoming_definition_edge_confidence_lists[definition_number]
+
+          -- Determine the weakened confidence of a definition.
+          local combined_edge_confidence
+          if #definition_edge_confidence_list == in_degree then
+            -- If a definition reaches all the incoming edges, use the maximum over the edge confidences as the combined edge
+            -- confidence.
+            combined_edge_confidence = math.max(table.unpack(definition_edge_confidence_list))
+          else
+            -- Otherwise, always use the combined edge confidence of `MAYBE`, regardless of the actual edge confidences.
+            combined_edge_confidence = MAYBE
+          end
+          assert(combined_edge_confidence >= MAYBE, "Edges shouldn't have confidences less than MAYBE")
+          -- Weaken the definition confidence with the combined edge confidence.
+          local updated_definition
+          if combined_edge_confidence < definition.confidence then
+            updated_definition = make_shallow_copy(definition)
+            updated_definition.weakened_confidence = combined_edge_confidence
+          else
+            updated_definition = definition
+          end
+          table.insert(incoming_definition_list, updated_definition)
+          if incoming_definition_index[updated_definition.csname] == nil then
+            incoming_definition_index[updated_definition.csname] = {}
+          end
+          table.insert(incoming_definition_index[updated_definition.csname], #incoming_definition_list)
+        end
+      end
+      return incoming_definition_list, incoming_definition_index
+    end
+
     -- Initialize a stack of changed statements to all well-behaved function (variant) definitions.
     local changed_statements_list, changed_statements_index = {}, {}
 
@@ -834,20 +896,18 @@ local function draw_group_wide_dynamic_edges(states, _, options)
 
       -- Pick a statement from the stack of changed statements.
       local chunk, statement_number = pop_changed_statement()
+
       local segment = chunk.segment
-
       local file_number = segment.location.file_number
-      local part_number = segment.location.part_number
-
       local state = states[file_number]
 
       local issues = state.issues
-      local results = state.results
-
-      local tokens = results.tokens[part_number]
 
       -- Get the byte range of a regular (non-macro) statement.
       local function statement_to_byte_range(...)
+        local part_number = segment.location.part_number
+        local tokens = state.results.tokens[part_number]
+
         local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
         local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
 
@@ -871,63 +931,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       end
 
       -- Determine the reaching definitions from before the current statement.
-      local incoming_definition_list, incoming_definition_index = {}, {}
-      do
-        local original_incoming_definition_list, original_incoming_definition_index = {}, {}
-        local original_incoming_definition_edge_confidence_lists = {}
-        local in_degree = 0
-        for _, in_edge_index in ipairs({explicit_in_edge_index, implicit_in_edge_index}) do
-          if in_edge_index[chunk] ~= nil and in_edge_index[chunk][statement_number] ~= nil then
-            for _, edge in ipairs(in_edge_index[chunk][statement_number]) do
-              if reaching_definition_lists[edge.from.chunk] ~= nil and
-                  reaching_definition_lists[edge.from.chunk][edge.from.statement_number] ~= nil then
-                in_degree = in_degree + 1
-                local reaching_definition_list = reaching_definition_lists[edge.from.chunk][edge.from.statement_number]
-                for _, definition in ipairs(reaching_definition_list) do
-                  -- Record the different incoming definitions together with the corresponding edge confidences.
-                  if original_incoming_definition_index[definition] == nil then
-                    assert(original_incoming_definition_edge_confidence_lists[definition] == nil)
-                    table.insert(original_incoming_definition_list, definition)
-                    original_incoming_definition_index[definition] = #original_incoming_definition_list
-                    table.insert(original_incoming_definition_edge_confidence_lists, {})
-                    assert(#original_incoming_definition_edge_confidence_lists == #original_incoming_definition_list)
-                  end
-                  local definition_number = original_incoming_definition_index[definition]
-                  table.insert(original_incoming_definition_edge_confidence_lists[definition_number], edge.confidence)
-                end
-              end
-            end
-          end
-        end
-        for definition_number, definition in ipairs(original_incoming_definition_list) do
-          local definition_edge_confidence_list = original_incoming_definition_edge_confidence_lists[definition_number]
-
-          -- Determine the weakened confidence of a definition.
-          local combined_edge_confidence
-          if #definition_edge_confidence_list == in_degree then
-            -- If a definition reaches all the incoming edges, use the maximum over the edge confidences as the combined edge
-            -- confidence.
-            combined_edge_confidence = math.max(table.unpack(definition_edge_confidence_list))
-          else
-            -- Otherwise, always use the combined edge confidence of `MAYBE`, regardless of the actual edge confidences.
-            combined_edge_confidence = MAYBE
-          end
-          assert(combined_edge_confidence >= MAYBE, "Edges shouldn't have confidences less than MAYBE")
-          -- Weaken the definition confidence with the combined edge confidence.
-          local updated_definition
-          if combined_edge_confidence < definition.confidence then
-            updated_definition = make_shallow_copy(definition)
-            updated_definition.weakened_confidence = combined_edge_confidence
-          else
-            updated_definition = definition
-          end
-          table.insert(incoming_definition_list, updated_definition)
-          if incoming_definition_index[updated_definition.csname] == nil then
-            incoming_definition_index[updated_definition.csname] = {}
-          end
-          table.insert(incoming_definition_index[updated_definition.csname], #incoming_definition_list)
-        end
-      end
+      local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, statement_number)
 
       -- Determine the definitions and undefinitions from the current statement.
       local current_definition_list, current_definition_index = {}, {}

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -6,6 +6,7 @@ local lexical_analysis = require("explcheck-lexical-analysis")
 local syntactic_analysis = require("explcheck-syntactic-analysis")
 local semantic_analysis = require("explcheck-semantic-analysis")
 local make_shallow_copy = require("explcheck-utils").make_shallow_copy
+local parsers = require("explcheck-parsers")
 
 local format_csname = lexical_analysis.format_csname
 local get_token_range_to_byte_range = lexical_analysis.get_token_range_to_byte_range
@@ -46,6 +47,8 @@ local range_flags = ranges.range_flags
 
 local EXCLUSIVE = range_flags.EXCLUSIVE
 local INCLUSIVE = range_flags.INCLUSIVE
+
+local lpeg = require("lpeg")
 
 local macro_statement_types = {
   FUNCTION_DEFINITIONS = "block of function (variant) (un)definitions",
@@ -1292,6 +1295,9 @@ local function draw_group_wide_dynamic_edges(states, _, options)
           goto next_file
         end
         local issues = state.issues
+        local imported_prefixes = get_option('imported_prefixes', options, state.pathname)
+        local l3prefixes_max_first_registered_date = get_option("l3prefixes_max_first_registered_date", options, state.pathname)
+        local expl3_well_known_csname = parsers.expl3_well_known_csname(l3prefixes_max_first_registered_date, imported_prefixes)
         for _, segment in ipairs(state.results.segments or {}) do
           local part_number = segment.location.part_number
           local tokens = state.results.tokens[part_number]
@@ -1353,6 +1359,10 @@ local function draw_group_wide_dynamic_edges(states, _, options)
 
                 -- Determine whether there are any definite definitions for a given control sequence name that reach the current statement.
                 local function any_definite_reaching_definitions(csname)
+                  if lpeg.match(expl3_well_known_csname, csname) ~= nil then
+                    -- Always consider definitions for well-known expl3 control sequence names to be reaching.
+                    return true
+                  end
                   for definition in get_reaching_definitions(csname) do
                     assert(definition.csname == csname)
                     assert(definition.macro_statement_number <= macro_statement_number)

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -523,7 +523,7 @@ local function is_well_behaved(statement)
   elseif statement.type == FUNCTION_DEFINITION then
     result = statement.defined_csname.type == TEXT and (statement.maybe_used or statement.maybe_multiply_defined)
   elseif statement.type == FUNCTION_UNDEFINITION then
-    result = statement.undefined_csname.type == TEXT and statement.maybe_used
+    result = statement.undefined_csname.type == TEXT and (statement.maybe_used or statement.maybe_multiply_defined)
   elseif statement.type == FUNCTION_VARIANT_DEFINITION then
     result = statement.defined_csname.type == TEXT and statement.maybe_used
   else

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -603,7 +603,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   local max_reaching_definition_inner_loops = get_option('max_reaching_definition_inner_loops', options)
   local max_reaching_definition_outer_loops = get_option('max_reaching_definition_outer_loops', options)
   local outer_loop_number = 1
-  repeat
+  while true do
     -- Guard against long (infinite?) loops.
     if outer_loop_number > max_reaching_definition_outer_loops then
       error(
@@ -825,7 +825,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     end
 
     -- Determine the definitions and undefinitions from the current statement.
-    local function get_current_definitions(chunk, macro_statement_number, incoming_definition_list, incoming_definition_index)
+    local function get_current_definitions(
+        chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, max_statement_number)
       local segment = chunk.segment
       local file_number = segment.location.file_number
       local state = states[file_number]
@@ -858,6 +859,9 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         end
         for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
           assert(not is_macro_statement(statement))
+          if max_statement_number ~= nil and statement_number > max_statement_number then
+            break
+          end
           if statement.type ~= FUNCTION_DEFINITION and
               statement.type ~= FUNCTION_UNDEFINITION and
               statement.type ~= FUNCTION_VARIANT_DEFINITION then
@@ -935,7 +939,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         end
         ::next_macro_statement::
       end
-      return current_definition_list, invalidated_statement_index
+      return current_definition_list, current_definition_index, invalidated_statement_index
     end
 
     -- Determine the reaching definitions after the current statement.
@@ -1093,7 +1097,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, statement_number)
 
       -- Determine the definitions and undefinitions from the current statement.
-      local current_definition_list, invalidated_statement_index
+      local current_definition_list, _, invalidated_statement_index
         = get_current_definitions(chunk, statement_number, incoming_definition_list, incoming_definition_index)
 
       -- Determine the reaching definitions after the current statement.
@@ -1278,7 +1282,89 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     end
 
     outer_loop_number = outer_loop_number + 1
-  until not any_edges_changed(previous_function_call_edges, current_function_call_edges)
+
+    if not any_edges_changed(previous_function_call_edges, current_function_call_edges) then
+      -- After the last outer-loop iteration, report any issues that require the knowledge of the reaching definitions
+      -- and not just the resulting edges before we have freed the corresponding variables.
+      for _, state in ipairs(states) do
+        -- Skip statements from files in the current file group that haven't reached the flow analysis.
+        if state.results.stopped_early then
+          goto next_file
+        end
+        local issues = state.issues
+        for _, segment in ipairs(state.results.segments or {}) do
+          local part_number = segment.location.part_number
+          local tokens = state.results.tokens[part_number]
+          local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
+          for _, chunk in ipairs(segment.chunks or {}) do
+            local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
+            for macro_statement_number, macro_statement in chunk.statement_range:enumerate(segment.macro_statements) do
+              if macro_statement.type ~= FUNCTION_DEFINITIONS then
+                goto next_macro_statement
+              end
+              for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
+                assert(not is_macro_statement(statement))
+                if statement.confidence ~= DEFINITELY or
+                    statement.type ~= FUNCTION_VARIANT_DEFINITION or
+                    statement.base_csname.type ~= TEXT then
+                  goto next_statement
+                end
+
+                -- Get the byte range of the current statement.
+                local function get_byte_range()
+                  local token_range = call_range_to_token_range(statement.call_range)
+                  local byte_range = token_range_to_byte_range(token_range)
+
+                  return byte_range
+                end
+
+                local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, macro_statement_number)
+                local current_definition_list, current_definition_index, invalidated_statement_index = get_current_definitions(
+                  chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, statement_number - 1)
+
+                -- Report function variants for an undefined function.
+                local any_definitions = false
+                for _, definition_list_and_index in ipairs({
+                      {incoming_definition_list, incoming_definition_index},
+                      {current_definition_list, current_definition_index},
+                    }) do
+                  local definition_list, definition_index = table.unpack(definition_list_and_index)
+                  for _, definition_number in ipairs(definition_index[statement.base_csname.payload] or {}) do
+                    local definition = definition_list[definition_number]
+                    assert(definition.csname == statement.base_csname.payload)
+                    assert(definition.macro_statement_number <= macro_statement_number)
+                    if definition.macro_statement_number == macro_statement_number then
+                      assert(definition.statement_number < statement_number)
+                    end
+                    if definition.confidence ~= DEFINITELY then
+                      goto next_definition
+                    end
+                    local other_statement = get_statement(definition.chunk, definition.macro_statement_number, definition.statement_number)
+                    if invalidated_statement_index[other_statement] then
+                      goto next_definition
+                    end
+                    any_definitions = true
+                    goto skip_following_definitions
+                    ::next_definition::
+                  end
+                end
+                ::skip_following_definitions::
+                if not any_definitions then
+                  local formatted_csname = format_csname(statement.base_csname.payload)
+                  issues:add("e504", "function variant for an undefined function", get_byte_range(), formatted_csname)
+                end
+
+                ::next_statement::
+              end
+              ::next_macro_statement::
+            end
+          end
+        end
+        ::next_file::
+      end
+      break
+    end
+  end
 
   -- Record edges.
   for _, edge in ipairs(current_function_call_edges) do

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1304,9 +1304,14 @@ local function draw_group_wide_dynamic_edges(states, _, options)
               end
               for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
                 assert(not is_macro_statement(statement))
-                if statement.confidence ~= DEFINITELY or
-                    statement.type ~= FUNCTION_VARIANT_DEFINITION or
-                    statement.base_csname.type ~= TEXT then
+                if statement.confidence ~= DEFINITELY then
+                  goto next_statement
+                end
+                if statement.type ~= FUNCTION_VARIANT_DEFINITION and
+                    (statement.type ~= FUNCTION_DEFINITION or statement.subtype ~= FUNCTION_DEFINITION_INDIRECT) then
+                  goto next_statement
+                end
+                if statement.base_csname.type ~= TEXT then
                   goto next_statement
                 end
 
@@ -1322,7 +1327,6 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                 local current_definition_list, current_definition_index, invalidated_statement_index = get_current_definitions(
                   chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, statement_number - 1)
 
-                -- Report function variants for an undefined function.
                 local any_definitions = false
                 for _, definition_list_and_index in ipairs({
                       {incoming_definition_list, incoming_definition_index},
@@ -1349,11 +1353,22 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                   end
                 end
                 ::skip_following_definitions::
+
                 if not any_definitions then
                   local formatted_csname = format_csname(statement.base_csname.payload)
-                  issues:add("e504", "function variant for an undefined function", get_byte_range(), formatted_csname)
-                end
+                  local byte_range = get_byte_range()
 
+                  -- Report function variants for an undefined function.
+                  if statement.type == FUNCTION_VARIANT_DEFINITION then
+                    issues:add("e504", "function variant for an undefined function", byte_range, formatted_csname)
+                  -- Report indirect function definitions from an undefined function.
+                  elseif statement.type == FUNCTION_DEFINITION then
+                    assert(statement.subtype == FUNCTION_DEFINITION_INDIRECT)
+                    issues:add("e506", "indirect function definition from an undefined function", byte_range, formatted_csname)
+                  else
+                    error('Unexpected statement type "' .. statement.type .. '" and subtype "' .. statement.subtype .. '"')
+                  end
+                end
                 ::next_statement::
               end
               ::next_macro_statement::

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -868,7 +868,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
         local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
 
-        local statement = _get_statement(chunk, macro_statement_number, statement_number)
+        local statement = get_statement(chunk, macro_statement_number, statement_number)
         assert(not is_macro_statement(statement))
 
         local token_range = call_range_to_token_range(statement.call_range)
@@ -1527,7 +1527,7 @@ local function report_issues(states, main_file_number, _)
     local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
     local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #content)
 
-    local statement = _get_statement(chunk, statement_number)
+    local statement = get_statement(chunk, statement_number)
     assert(not is_macro_statement(statement))
 
     local token_range = call_range_to_token_range(statement.call_range)
@@ -1541,7 +1541,7 @@ local function report_issues(states, main_file_number, _)
     local chunk, statement_number = table.unpack(chunk_and_statement_number)
     if states.results.edge_indexes.function_call[chunk] == nil or
         states.results.edge_indexes.function_call[chunk][statement_number] == nil then
-      local statement = _get_statement(chunk, statement_number)
+      local statement = get_statement(chunk, statement_number)
       local byte_range = statement_to_byte_range(chunk, statement_number)
       local csname = statement.used_csname
 

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1307,13 +1307,6 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                 if statement.confidence ~= DEFINITELY then
                   goto next_statement
                 end
-                if statement.type ~= FUNCTION_VARIANT_DEFINITION and
-                    (statement.type ~= FUNCTION_DEFINITION or statement.subtype ~= FUNCTION_DEFINITION_INDIRECT) then
-                  goto next_statement
-                end
-                if statement.base_csname.type ~= TEXT then
-                  goto next_statement
-                end
 
                 -- Get the byte range of the current statement.
                 local function get_byte_range()
@@ -1323,34 +1316,62 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                   return byte_range
                 end
 
-                local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, macro_statement_number)
-                local current_definition_list, current_definition_index, invalidated_statement_index = get_current_definitions(
-                  chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, statement_number - 1)
+                -- Get definitions that reach the current statement
+                local function get_reaching_definitions(csname)
+                  local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, macro_statement_number)
+                  local current_definition_list, current_definition_index, invalidated_statement_index = get_current_definitions(
+                    chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, statement_number - 1)
+
+                  local definition_lists = {incoming_definition_list, current_definition_list}
+                  local definition_indexes = {incoming_definition_index[csname] or {}, current_definition_index[csname] or {}}
+                  local current_definition_list_number, current_definition_number = 1, 1
+
+                  return function()
+                    while true do
+                      if current_definition_list_number > #definition_lists then
+                        return nil
+                      end
+                      local definition_list = definition_lists[current_definition_list_number]
+                      local definition_index = definition_indexes[current_definition_list_number]
+                      if current_definition_number > #definition_index then
+                        current_definition_list_number = current_definition_list_number + 1
+                        current_definition_number = 1
+                        goto continue
+                      end
+                      local definition_number = definition_index[current_definition_number]
+                      current_definition_number = current_definition_number + 1
+                      local definition = definition_list[definition_number]
+                      local other_statement
+                        = get_statement(definition.chunk, definition.macro_statement_number, definition.statement_number)
+                      if not invalidated_statement_index[other_statement] then
+                        return definition
+                      end
+                      ::continue::
+                    end
+                  end
+                end
+
+                if (statement.type ~= FUNCTION_VARIANT_DEFINITION) and
+                    (statement.type ~= FUNCTION_DEFINITION or statement.subtype ~= FUNCTION_DEFINITION_INDIRECT) then
+                  goto next_statement
+                end
+                if statement.base_csname.type ~= TEXT then
+                  goto next_statement
+                end
 
                 local any_definitions = false
-                for _, definition_list_and_index in ipairs({
-                      {incoming_definition_list, incoming_definition_index},
-                      {current_definition_list, current_definition_index},
-                    }) do
-                  local definition_list, definition_index = table.unpack(definition_list_and_index)
-                  for _, definition_number in ipairs(definition_index[statement.base_csname.payload] or {}) do
-                    local definition = definition_list[definition_number]
-                    assert(definition.csname == statement.base_csname.payload)
-                    assert(definition.macro_statement_number <= macro_statement_number)
-                    if definition.macro_statement_number == macro_statement_number then
-                      assert(definition.statement_number < statement_number)
-                    end
-                    if definition.confidence ~= DEFINITELY then
-                      goto next_definition
-                    end
-                    local other_statement = get_statement(definition.chunk, definition.macro_statement_number, definition.statement_number)
-                    if invalidated_statement_index[other_statement] then
-                      goto next_definition
-                    end
-                    any_definitions = true
-                    goto skip_following_definitions
-                    ::next_definition::
+                for definition in get_reaching_definitions(statement.base_csname.payload) do
+                  assert(definition.csname == statement.base_csname.payload)
+                  assert(definition.macro_statement_number <= macro_statement_number)
+                  if definition.macro_statement_number == macro_statement_number then
+                    assert(definition.statement_number < statement_number)
                   end
+                  if definition.confidence ~= DEFINITELY then
+                    goto next_definition
+                  end
+                  any_definitions = true
+                  goto skip_following_definitions
+                  ::next_definition::
                 end
                 ::skip_following_definitions::
 

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1354,7 +1354,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                 -- Determine whether there are any definite definitions for a given control sequence name that reach the current statement.
                 local function any_definite_reaching_definitions(csname)
                   for definition in get_reaching_definitions(csname) do
-                    assert(definition.csname == statement.base_csname.payload)
+                    assert(definition.csname == csname)
                     assert(definition.macro_statement_number <= macro_statement_number)
                     if definition.macro_statement_number == macro_statement_number then
                       assert(definition.statement_number < statement_number)

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1346,7 +1346,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
 
                 -- Get definitions for a given control sequence name that reach the current statement.
                 local function get_reaching_definitions(csname)
-                  local incoming_definition_list, incoming_definition_index = get_incoming_definitions(states, chunk, macro_statement_number)
+                  local incoming_definition_list, incoming_definition_index
+                    = get_incoming_definitions(states, chunk, macro_statement_number)
                   local current_definition_list, current_definition_index, invalidated_statement_index = get_current_definitions(
                     states, chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, statement_number - 1)
 

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -413,7 +413,7 @@ local function draw_group_wide_static_edges(states, _, _)
 
   -- Record edges from potentially inputting a file from the file group after every other file from the file group.
   for file_number, state in ipairs(states) do
-    if states[file_number].results.stopped_early then
+    if state.results.stopped_early then
       goto next_file
     end
     if state.results.last_part_with_chunks == nil then
@@ -424,7 +424,7 @@ local function draw_group_wide_static_edges(states, _, _)
     assert(from_chunk ~= nil)
     local from_statement_number = from_chunk.statement_range:stop() + 1
     for other_file_number, other_state in ipairs(states) do
-      if states[other_file_number].results.stopped_early then
+      if other_state.results.stopped_early then
         goto next_other_file
       end
       if file_number == other_file_number then
@@ -553,9 +553,9 @@ local function draw_group_wide_dynamic_edges(states, _, options)
 
   -- Collect a list of well-behaved function definition and call statements.
   local function_call_list, function_definition_list = {}, {}
-  for file_number, state in ipairs(states) do
+  for _, state in ipairs(states) do
     -- Skip statements from files in the current file group that haven't reached the flow analysis.
-    if states[file_number].results.stopped_early then
+    if states.results.stopped_early then
       goto next_file
     end
     for _, segment in ipairs(state.results.segments or {}) do
@@ -681,9 +681,9 @@ local function draw_group_wide_dynamic_edges(states, _, options)
 
     -- Index all implicit incoming and outgoing pseudo-edges as well.
     local implicit_in_edge_index, implicit_out_edge_index = {}, {}
-    for file_number, state in ipairs(states) do
+    for _, state in ipairs(states) do
       -- Skip statements from files in the current file group that haven't reached the flow analysis.
-      if states[file_number].results.stopped_early then
+      if state.results.stopped_early then
         goto next_file
       end
       for _, segment in ipairs(state.results.segments or {}) do
@@ -1300,7 +1300,7 @@ local function report_issues(states, main_file_number, _)
     end
   end
 
-  -- Get the byte range of a statement.
+  -- Get the byte range of a regular (non-macro) statement.
   local function statement_to_byte_range(chunk, statement_number)
     local segment = chunk.segment
     assert(segment.location.file_number == main_file_number)
@@ -1313,6 +1313,7 @@ local function report_issues(states, main_file_number, _)
     local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #content)
 
     local statement = _get_statement(chunk, statement_number)
+    assert(not is_macro_statement(statement))
 
     local token_range = call_range_to_token_range(statement.call_range)
     local byte_range = token_range_to_byte_range(token_range)

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -603,7 +603,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   local max_reaching_definition_inner_loops = get_option('max_reaching_definition_inner_loops', options)
   local max_reaching_definition_outer_loops = get_option('max_reaching_definition_outer_loops', options)
   local outer_loop_number = 1
-  repeat
+  while true do
     -- Guard against long (infinite?) loops.
     if outer_loop_number > max_reaching_definition_outer_loops then
       error(
@@ -1230,7 +1230,74 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     end
 
     outer_loop_number = outer_loop_number + 1
-  until not any_edges_changed(previous_function_call_edges, current_function_call_edges)
+
+    if not any_edges_changed(previous_function_call_edges, current_function_call_edges) then
+      -- After the last outer-loop iteration, report any issues that require the knowledge of the reaching definitions
+      -- and not just the resulting edges before we have freed the corresponding variables.
+      for _, state in ipairs(states) do
+        -- Skip statements from files in the current file group that haven't reached the flow analysis.
+        if state.results.stopped_early then
+          goto next_file
+        end
+        local issues = state.issues
+        for _, segment in ipairs(state.results.segments or {}) do
+          local part_number = segment.location.part_number
+          local tokens = state.results.tokens[part_number]
+          local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
+          for _, chunk in ipairs(segment.chunks or {}) do
+            local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
+            for macro_statement_number, macro_statement in chunk.statement_range:enumerate(segment.macro_statements) do
+              if macro_statement.type ~= FUNCTION_DEFINITIONS then
+                goto next_macro_statement
+              end
+              for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
+                assert(not is_macro_statement(statement))
+                if statement.confidence ~= DEFINITELY or
+                    statement.type ~= FUNCTION_DEFINITION or
+                    statement.maybe_redefinition or
+                    statement.defined_csname.type ~= TEXT then
+                  goto next_statement
+                end
+                if reaching_definition_indexes[chunk] == nil or
+                    reaching_definition_indexes[chunk][macro_statement_number] == nil then
+                  goto next_statement
+                end
+                local reaching_definition_index = reaching_definition_indexes[chunk][macro_statement_number]
+
+                -- Get the byte range of the current statement.
+                local function get_byte_range()
+                  local token_range = call_range_to_token_range(statement.call_range)
+                  local byte_range = token_range_to_byte_range(token_range)
+
+                  return byte_range
+                end
+
+                -- Report multiply defined functions.
+                for _, definition in ipairs(reaching_definition_index[statement.defined_csname.payload] or {}) do
+                  assert(definition.csname == statement.defined_csname.payload)
+                  if definition.confidence ~= DEFINITELY then
+                    goto next_definition
+                  end
+                  if definition.macro_statement_number == macro_statement_number and
+                      definition.statement_number >= statement_number then
+                    -- Exclude the same statement as well as any following statements from the same macro-statement.
+                    goto next_definition
+                  end
+                  issues:add("e500", "multiply defined function", get_byte_range(), format_csname(definition.csname))
+                  ::next_definition::
+                end
+
+                ::next_statement::
+              end
+              ::next_macro_statement::
+            end
+          end
+        end
+        ::next_file::
+      end
+      break
+    end
+  end
 
   -- Record edges.
   for _, edge in ipairs(current_function_call_edges) do

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1369,8 +1369,9 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                       statement.type == FUNCTION_VARIANT_DEFINITION or
                       statement.type == FUNCTION_DEFINITION and statement.subtype == FUNCTION_DEFINITION_INDIRECT
                     ) and statement.base_csname.type == TEXT then
-                  if not any_definite_reaching_definitions(statement.base_csname.payload) then
-                    local formatted_csname = format_csname(statement.base_csname.payload)
+                  local base_csname = statement.base_csname.payload
+                  if not any_definite_reaching_definitions(base_csname) then
+                    local formatted_csname = format_csname(base_csname)
                     local byte_range = get_byte_range()
 
                     -- Report function variants for an undefined function.
@@ -1391,8 +1392,9 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                     -- TODO: Currently, we only consider function calls from within top-level code (`segment.nesting_depth == 1`).
                     -- Ideally, we would consider all function calls that are reachable from top-level code.
                     and segment.nesting_depth == 1 then
-                  if not any_definite_reaching_definitions(statement.defined_csname.payload) then
-                    local formatted_csname = format_csname(statement.defined_csname.payload)
+                  local defined_csname = statement.defined_csname.payload
+                  if not any_definite_reaching_definitions(defined_csname) then
+                    local formatted_csname = format_csname(defined_csname)
                     local byte_range = get_byte_range()
                     issues:add("w507", "setting a function before definition", byte_range, formatted_csname)
                   end

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -158,6 +158,12 @@ local function _get_statement(chunk, macro_statement_number, statement_number)
   end
 end
 
+-- Resolve a chunk and a statement number to a statement, with extra invariants checked.
+local function get_statement(states, chunk, macro_statement_number, statement_number)
+  assert(not states[chunk.segment.location.file_number].results.stopped_early)
+  return _get_statement(chunk, macro_statement_number, statement_number)
+end
+
 -- Get a text representation of a statement or a pseudo-statement "after" a chunk.
 ---@diagnostic disable-next-line:unused-function
 local function format_statement(chunk, macro_statement_number, statement_number)
@@ -539,13 +545,6 @@ end
 -- Check whether a statement is "interesting". A statement is interesting if it has the potential to consume or affect
 -- the reaching definitions other than just passing along the definitions from the previous statement in the chunk.
 local function _is_interesting(states, chunk, macro_statement_number)
-
-  -- Resolve the chunk and statement number to a statement.
-  local function get_statement()
-    assert(not states[chunk.segment.location.file_number].results.stopped_early)
-    return _get_statement(chunk, macro_statement_number)
-  end
-
   -- Chunk boundaries are interesting.
   if macro_statement_number == chunk.statement_range:start() or macro_statement_number == chunk.statement_range:stop() + 1 then
     return true
@@ -558,7 +557,7 @@ local function _is_interesting(states, chunk, macro_statement_number)
     return true
   end
   -- Well-behaved statements are interesting.
-  local macro_statement = get_statement()
+  local macro_statement = get_statement(states, chunk, macro_statement_number)
   if macro_statement.type == FUNCTION_CALL and is_well_behaved(macro_statement) then
     return true
   end
@@ -583,6 +582,268 @@ local function _is_interesting(states, chunk, macro_statement_number)
   return false
 end
 
+-- Determine the reaching definitions from before the current statement.
+local function get_incoming_definitions(states, chunk, macro_statement_number)
+  local incoming_definition_list, incoming_definition_index = {}, {}
+  do
+    local original_incoming_definition_list, original_incoming_definition_index = {}, {}
+    local original_incoming_definition_edge_confidence_lists = {}
+    local in_degree = 0
+    for _, in_edge_index in ipairs({states.results.edge_indexes.explicit_in, states.results.edge_indexes.implicit_in}) do
+      if in_edge_index[chunk] ~= nil and in_edge_index[chunk][macro_statement_number] ~= nil then
+        for _, edge in ipairs(in_edge_index[chunk][macro_statement_number]) do
+          if states.results.reaching_definitions.lists[edge.from.chunk] ~= nil and
+              states.results.reaching_definitions.lists[edge.from.chunk][edge.from.statement_number] ~= nil then
+            in_degree = in_degree + 1
+            local reaching_definition_list
+              = states.results.reaching_definitions.lists[edge.from.chunk][edge.from.statement_number]
+            for _, definition in ipairs(reaching_definition_list) do
+              -- Record the different incoming definitions together with the corresponding edge confidences.
+              if original_incoming_definition_index[definition] == nil then
+                assert(original_incoming_definition_edge_confidence_lists[definition] == nil)
+                table.insert(original_incoming_definition_list, definition)
+                original_incoming_definition_index[definition] = #original_incoming_definition_list
+                table.insert(original_incoming_definition_edge_confidence_lists, {})
+                assert(#original_incoming_definition_edge_confidence_lists == #original_incoming_definition_list)
+              end
+              local definition_number = original_incoming_definition_index[definition]
+              table.insert(original_incoming_definition_edge_confidence_lists[definition_number], edge.confidence)
+            end
+          end
+        end
+      end
+    end
+    for definition_number, definition in ipairs(original_incoming_definition_list) do
+      local definition_edge_confidence_list = original_incoming_definition_edge_confidence_lists[definition_number]
+
+      -- Determine the weakened confidence of a definition.
+      local combined_edge_confidence
+      if #definition_edge_confidence_list == in_degree then
+        -- If a definition reaches all the incoming edges, use the maximum over the edge confidences as the combined edge
+        -- confidence.
+        combined_edge_confidence = math.max(table.unpack(definition_edge_confidence_list))
+      else
+        -- Otherwise, always use the combined edge confidence of `MAYBE`, regardless of the actual edge confidences.
+        combined_edge_confidence = MAYBE
+      end
+      assert(combined_edge_confidence >= MAYBE, "Edges shouldn't have confidences less than MAYBE")
+      -- Weaken the definition confidence with the combined edge confidence.
+      local updated_definition
+      if combined_edge_confidence < definition.confidence then
+        updated_definition = make_shallow_copy(definition)
+        updated_definition.weakened_confidence = combined_edge_confidence
+      else
+        updated_definition = definition
+      end
+      table.insert(incoming_definition_list, updated_definition)
+      if incoming_definition_index[updated_definition.csname] == nil then
+        incoming_definition_index[updated_definition.csname] = {}
+      end
+      table.insert(incoming_definition_index[updated_definition.csname], #incoming_definition_list)
+    end
+  end
+  return incoming_definition_list, incoming_definition_index
+end
+
+-- Determine the definitions and undefinitions from the current statement.
+local function get_current_definitions(
+    states, chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, max_statement_number)
+
+  local segment = chunk.segment
+  local file_number = segment.location.file_number
+  local state = states[file_number]
+
+  local issues = state.issues
+
+  -- Get the byte range of a regular (non-macro) statement.
+  local function statement_to_byte_range(statement_number)
+    local part_number = segment.location.part_number
+    local tokens = state.results.tokens[part_number]
+
+    local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
+    local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
+
+    local statement = get_statement(states, chunk, macro_statement_number, statement_number)
+    assert(not is_macro_statement(statement))
+
+    local token_range = call_range_to_token_range(statement.call_range)
+    local byte_range = token_range_to_byte_range(token_range)
+
+    return byte_range
+  end
+
+  local current_definition_list, current_definition_index = {}, {}
+  local invalidated_statement_index = {}
+  if macro_statement_number <= chunk.statement_range:stop() then  -- Unless this is a pseudo-statement "after" a chunk.
+    local macro_statement = get_statement(states, chunk, macro_statement_number)
+    if macro_statement.type ~= FUNCTION_DEFINITIONS then
+      goto next_macro_statement
+    end
+    for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
+      assert(not is_macro_statement(statement))
+      if max_statement_number ~= nil and statement_number > max_statement_number then
+        break
+      end
+      if statement.type ~= FUNCTION_DEFINITION and
+          statement.type ~= FUNCTION_UNDEFINITION and
+          statement.type ~= FUNCTION_VARIANT_DEFINITION then
+        goto next_statement
+      end
+      if not is_well_behaved(statement) then
+        goto next_statement
+      end
+      local defined_or_undefined_csname
+      if statement.type == FUNCTION_DEFINITION or statement.type == FUNCTION_VARIANT_DEFINITION then
+        -- Record function and function variant definitions.
+        assert(statement.defined_csname.type == TEXT)
+        defined_or_undefined_csname = statement.defined_csname.payload
+        local definition = {
+          csname = defined_or_undefined_csname,
+          confidence = statement.confidence,
+          chunk = chunk,
+          macro_statement_number = macro_statement_number,
+          statement_number = is_macro_statement(macro_statement) and statement_number or nil,
+        }
+        assert(definition.confidence >= MAYBE, "Function definitions shouldn't have confidences less than MAYBE")
+        table.insert(current_definition_list, definition)
+        if current_definition_index[definition.csname] == nil then
+          current_definition_index[definition.csname] = {}
+        end
+        table.insert(current_definition_index[definition.csname], #current_definition_list)
+      elseif statement.type == FUNCTION_UNDEFINITION then
+        defined_or_undefined_csname = statement.undefined_csname.payload
+      else
+        error('Unexpected statement type "' .. statement.type .. '"')
+      end
+      if statement.confidence == DEFINITELY then
+        -- Invalidate definitions of the same control sequence names from before the current statement.
+        for _, definition_list_and_index in ipairs({
+              {incoming_definition_list, incoming_definition_index},
+              {current_definition_list, current_definition_index},
+            }) do
+          local definition_list, definition_index = table.unpack(definition_list_and_index)
+          for _, incoming_definition_number in ipairs(definition_index[defined_or_undefined_csname] or {}) do
+            local incoming_definition = definition_list[incoming_definition_number]
+            assert(incoming_definition.csname == defined_or_undefined_csname)
+            local incoming_statement = get_statement(
+              states,
+              incoming_definition.chunk,
+              incoming_definition.macro_statement_number,
+              incoming_definition.statement_number
+            )
+            assert(incoming_statement.defined_csname.payload == defined_or_undefined_csname)
+            if incoming_statement ~= statement and not invalidated_statement_index[incoming_statement] then
+              if incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition
+                  or incoming_statement.type == FUNCTION_VARIANT_DEFINITION then
+                if statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition
+                    or statement.type == FUNCTION_VARIANT_DEFINITION then
+                  local byte_range = statement_to_byte_range(statement_number)
+                  local formatted_csname = format_csname(defined_or_undefined_csname)
+                  -- Report a multiply defined function.
+                  if statement.type == FUNCTION_DEFINITION then
+                    issues:add("e500", "multiply defined function", byte_range, formatted_csname)
+                  -- Report a multiply defined function variant.
+                  elseif statement.type == FUNCTION_VARIANT_DEFINITION then
+                    issues:add("w501", "multiply defined function variant", byte_range, formatted_csname)
+                  else
+                    error('Unexpected statement type "' .. statement.type .. '"')
+                  end
+                end
+              end
+              invalidated_statement_index[incoming_statement] = true
+            end
+          end
+        end
+      end
+      -- If we previously invalidated a definition that originates from the current statement but reached us from before the
+      -- current statement due to a cycle in the flow-graph, undo the invalidation.
+      invalidated_statement_index[statement] = false
+      ::next_statement::
+    end
+    ::next_macro_statement::
+  end
+  return current_definition_list, current_definition_index, invalidated_statement_index
+end
+
+-- Determine the reaching definitions after the current statement.
+local function get_outgoing_definitions(states, incoming_definition_list, current_definition_list, invalidated_statement_index)
+  local updated_definition_list, updated_definition_index = {}, {}
+  local current_reaching_statement_index = {}
+  for _, definition_list in ipairs({incoming_definition_list, current_definition_list}) do
+    for _, definition in ipairs(definition_list) do
+      local statement = get_statement(states, definition.chunk, definition.macro_statement_number, definition.statement_number)
+      assert(is_well_behaved(statement))
+      -- Skip invalidated definitions.
+      if invalidated_statement_index[statement] then
+        goto next_definition
+      end
+      -- Record the first occurrence of a definition.
+      if current_reaching_statement_index[statement] == nil then
+        table.insert(updated_definition_list, definition)
+        -- Also index the reaching definitions by defined control sequence names.
+        if updated_definition_index[definition.csname] == nil then
+          updated_definition_index[definition.csname] = {}
+        end
+        table.insert(updated_definition_index[definition.csname], definition)
+        current_reaching_statement_index[statement] = {
+          #updated_definition_list,
+          #updated_definition_index[definition.csname],
+        }
+      -- For repeated occurrences of a definition, keep the ones with the highest confidence.
+      else
+        local other_definition_list_number, other_definition_index_number = table.unpack(current_reaching_statement_index[statement])
+        -- If the current occurrence has a higher confidence, replace the previous occurrence with it.
+        local other_definition = updated_definition_list[other_definition_list_number]
+        if definition.confidence > other_definition.confidence then
+          updated_definition_list[other_definition_list_number] = definition
+          updated_definition_index[definition.csname][other_definition_index_number] = definition
+        end
+      end
+      ::next_definition::
+    end
+  end
+  return updated_definition_list, updated_definition_index, current_reaching_statement_index
+end
+
+-- Determine whether the reaching definitions after the current statement have changed.
+local function have_reaching_definitions_changed(states, chunk, statement_number, updated_definition_list, current_reaching_statement_index)
+  -- Determine the previous set of definitions, if any.
+  if states.results.reaching_definitions.lists[chunk] == nil then
+    return true
+  end
+  if states.results.reaching_definitions.lists[chunk][statement_number] == nil then
+    return true
+  end
+  local previous_definition_list = states.results.reaching_definitions.lists[chunk][statement_number]
+  assert(previous_definition_list ~= nil)
+  assert(#previous_definition_list <= #updated_definition_list)
+
+  -- Quickly check for inequality using set cardinalities.
+  if #previous_definition_list ~= #updated_definition_list then
+    return true
+  end
+
+  -- Check that the definitions and their confidences are the same.
+  for _, previous_definition in ipairs(previous_definition_list) do
+    local statement = get_statement(
+      states,
+      previous_definition.chunk,
+      previous_definition.macro_statement_number,
+      previous_definition.statement_number
+    )
+    if current_reaching_statement_index[statement] == nil then
+      return true
+    end
+    local updated_definition_list_number, _ = table.unpack(current_reaching_statement_index[statement])
+    local updated_definition = updated_definition_list[updated_definition_list_number]
+    if previous_definition.confidence ~= updated_definition.confidence then
+      return true
+    end
+  end
+
+  return false
+end
+
 -- Draw "dynamic" edges between chunks between all files in a file group. A dynamic edge requires estimation.
 local function draw_group_wide_dynamic_edges(states, _, options)
   -- Draw dynamic edges once between all files in the file group, not just individual files.
@@ -594,12 +855,6 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   -- Index an edge in an edge index.
   local function index_edge(edge_index, index_key, edge)
     return _index_edge(states, edge_index, index_key, edge)
-  end
-
-  -- Resolve a chunk and a statement number to a statement.
-  local function get_statement(chunk, macro_statement_number, statement_number)
-    assert(not states[chunk.segment.location.file_number].results.stopped_early)
-    return _get_statement(chunk, macro_statement_number, statement_number)
   end
 
   -- Check whether a statement is "interesting". A statement is interesting if it has the potential to consume or affect
@@ -788,265 +1043,6 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       ::next_file::
     end
 
-    -- Determine the reaching definitions from before the current statement.
-    local function get_incoming_definitions(chunk, statement_number)
-      local incoming_definition_list, incoming_definition_index = {}, {}
-      do
-        local original_incoming_definition_list, original_incoming_definition_index = {}, {}
-        local original_incoming_definition_edge_confidence_lists = {}
-        local in_degree = 0
-        for _, in_edge_index in ipairs({states.results.edge_indexes.explicit_in, states.results.edge_indexes.implicit_in}) do
-          if in_edge_index[chunk] ~= nil and in_edge_index[chunk][statement_number] ~= nil then
-            for _, edge in ipairs(in_edge_index[chunk][statement_number]) do
-              if states.results.reaching_definitions.lists[edge.from.chunk] ~= nil and
-                  states.results.reaching_definitions.lists[edge.from.chunk][edge.from.statement_number] ~= nil then
-                in_degree = in_degree + 1
-                local reaching_definition_list
-                  = states.results.reaching_definitions.lists[edge.from.chunk][edge.from.statement_number]
-                for _, definition in ipairs(reaching_definition_list) do
-                  -- Record the different incoming definitions together with the corresponding edge confidences.
-                  if original_incoming_definition_index[definition] == nil then
-                    assert(original_incoming_definition_edge_confidence_lists[definition] == nil)
-                    table.insert(original_incoming_definition_list, definition)
-                    original_incoming_definition_index[definition] = #original_incoming_definition_list
-                    table.insert(original_incoming_definition_edge_confidence_lists, {})
-                    assert(#original_incoming_definition_edge_confidence_lists == #original_incoming_definition_list)
-                  end
-                  local definition_number = original_incoming_definition_index[definition]
-                  table.insert(original_incoming_definition_edge_confidence_lists[definition_number], edge.confidence)
-                end
-              end
-            end
-          end
-        end
-        for definition_number, definition in ipairs(original_incoming_definition_list) do
-          local definition_edge_confidence_list = original_incoming_definition_edge_confidence_lists[definition_number]
-
-          -- Determine the weakened confidence of a definition.
-          local combined_edge_confidence
-          if #definition_edge_confidence_list == in_degree then
-            -- If a definition reaches all the incoming edges, use the maximum over the edge confidences as the combined edge
-            -- confidence.
-            combined_edge_confidence = math.max(table.unpack(definition_edge_confidence_list))
-          else
-            -- Otherwise, always use the combined edge confidence of `MAYBE`, regardless of the actual edge confidences.
-            combined_edge_confidence = MAYBE
-          end
-          assert(combined_edge_confidence >= MAYBE, "Edges shouldn't have confidences less than MAYBE")
-          -- Weaken the definition confidence with the combined edge confidence.
-          local updated_definition
-          if combined_edge_confidence < definition.confidence then
-            updated_definition = make_shallow_copy(definition)
-            updated_definition.weakened_confidence = combined_edge_confidence
-          else
-            updated_definition = definition
-          end
-          table.insert(incoming_definition_list, updated_definition)
-          if incoming_definition_index[updated_definition.csname] == nil then
-            incoming_definition_index[updated_definition.csname] = {}
-          end
-          table.insert(incoming_definition_index[updated_definition.csname], #incoming_definition_list)
-        end
-      end
-      return incoming_definition_list, incoming_definition_index
-    end
-
-    -- Determine the definitions and undefinitions from the current statement.
-    local function get_current_definitions(
-        chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, max_statement_number)
-      local segment = chunk.segment
-      local file_number = segment.location.file_number
-      local state = states[file_number]
-
-      local issues = state.issues
-
-      -- Get the byte range of a regular (non-macro) statement.
-      local function statement_to_byte_range(statement_number)
-        local part_number = segment.location.part_number
-        local tokens = state.results.tokens[part_number]
-
-        local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
-        local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
-
-        local statement = get_statement(chunk, macro_statement_number, statement_number)
-        assert(not is_macro_statement(statement))
-
-        local token_range = call_range_to_token_range(statement.call_range)
-        local byte_range = token_range_to_byte_range(token_range)
-
-        return byte_range
-      end
-
-      local current_definition_list, current_definition_index = {}, {}
-      local invalidated_statement_index = {}
-      if macro_statement_number <= chunk.statement_range:stop() then  -- Unless this is a pseudo-statement "after" a chunk.
-        local macro_statement = get_statement(chunk, macro_statement_number)
-        if macro_statement.type ~= FUNCTION_DEFINITIONS then
-          goto next_macro_statement
-        end
-        for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
-          assert(not is_macro_statement(statement))
-          if max_statement_number ~= nil and statement_number > max_statement_number then
-            break
-          end
-          if statement.type ~= FUNCTION_DEFINITION and
-              statement.type ~= FUNCTION_UNDEFINITION and
-              statement.type ~= FUNCTION_VARIANT_DEFINITION then
-            goto next_statement
-          end
-          if not is_well_behaved(statement) then
-            goto next_statement
-          end
-          local defined_or_undefined_csname
-          if statement.type == FUNCTION_DEFINITION or statement.type == FUNCTION_VARIANT_DEFINITION then
-            -- Record function and function variant definitions.
-            assert(statement.defined_csname.type == TEXT)
-            defined_or_undefined_csname = statement.defined_csname.payload
-            local definition = {
-              csname = defined_or_undefined_csname,
-              confidence = statement.confidence,
-              chunk = chunk,
-              macro_statement_number = macro_statement_number,
-              statement_number = is_macro_statement(macro_statement) and statement_number or nil,
-            }
-            assert(definition.confidence >= MAYBE, "Function definitions shouldn't have confidences less than MAYBE")
-            table.insert(current_definition_list, definition)
-            if current_definition_index[definition.csname] == nil then
-              current_definition_index[definition.csname] = {}
-            end
-            table.insert(current_definition_index[definition.csname], #current_definition_list)
-          elseif statement.type == FUNCTION_UNDEFINITION then
-            defined_or_undefined_csname = statement.undefined_csname.payload
-          else
-            error('Unexpected statement type "' .. statement.type .. '"')
-          end
-          if statement.confidence == DEFINITELY then
-            -- Invalidate definitions of the same control sequence names from before the current statement.
-            for _, definition_list_and_index in ipairs({
-                  {incoming_definition_list, incoming_definition_index},
-                  {current_definition_list, current_definition_index},
-                }) do
-              local definition_list, definition_index = table.unpack(definition_list_and_index)
-              for _, incoming_definition_number in ipairs(definition_index[defined_or_undefined_csname] or {}) do
-                local incoming_definition = definition_list[incoming_definition_number]
-                assert(incoming_definition.csname == defined_or_undefined_csname)
-                local incoming_statement = get_statement(
-                  incoming_definition.chunk,
-                  incoming_definition.macro_statement_number,
-                  incoming_definition.statement_number
-                )
-                assert(incoming_statement.defined_csname.payload == defined_or_undefined_csname)
-                if incoming_statement ~= statement and not invalidated_statement_index[incoming_statement] then
-                  if incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition
-                      or incoming_statement.type == FUNCTION_VARIANT_DEFINITION then
-                    if statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition
-                        or statement.type == FUNCTION_VARIANT_DEFINITION then
-                      local byte_range = statement_to_byte_range(statement_number)
-                      local formatted_csname = format_csname(defined_or_undefined_csname)
-                      -- Report a multiply defined function.
-                      if statement.type == FUNCTION_DEFINITION then
-                        issues:add("e500", "multiply defined function", byte_range, formatted_csname)
-                      -- Report a multiply defined function variant.
-                      elseif statement.type == FUNCTION_VARIANT_DEFINITION then
-                        issues:add("w501", "multiply defined function variant", byte_range, formatted_csname)
-                      else
-                        error('Unexpected statement type "' .. statement.type .. '"')
-                      end
-                    end
-                  end
-                  invalidated_statement_index[incoming_statement] = true
-                end
-              end
-            end
-          end
-          -- If we previously invalidated a definition that originates from the current statement but reached us from before the
-          -- current statement due to a cycle in the flow-graph, undo the invalidation.
-          invalidated_statement_index[statement] = false
-          ::next_statement::
-        end
-        ::next_macro_statement::
-      end
-      return current_definition_list, current_definition_index, invalidated_statement_index
-    end
-
-    -- Determine the reaching definitions after the current statement.
-    local function get_outgoing_definitions(incoming_definition_list, current_definition_list, invalidated_statement_index)
-      local updated_definition_list, updated_definition_index = {}, {}
-      local current_reaching_statement_index = {}
-      for _, definition_list in ipairs({incoming_definition_list, current_definition_list}) do
-        for _, definition in ipairs(definition_list) do
-          local statement = get_statement(definition.chunk, definition.macro_statement_number, definition.statement_number)
-          assert(is_well_behaved(statement))
-          -- Skip invalidated definitions.
-          if invalidated_statement_index[statement] then
-            goto next_definition
-          end
-          -- Record the first occurrence of a definition.
-          if current_reaching_statement_index[statement] == nil then
-            table.insert(updated_definition_list, definition)
-            -- Also index the reaching definitions by defined control sequence names.
-            if updated_definition_index[definition.csname] == nil then
-              updated_definition_index[definition.csname] = {}
-            end
-            table.insert(updated_definition_index[definition.csname], definition)
-            current_reaching_statement_index[statement] = {
-              #updated_definition_list,
-              #updated_definition_index[definition.csname],
-            }
-          -- For repeated occurrences of a definition, keep the ones with the highest confidence.
-          else
-            local other_definition_list_number, other_definition_index_number = table.unpack(current_reaching_statement_index[statement])
-            -- If the current occurrence has a higher confidence, replace the previous occurrence with it.
-            local other_definition = updated_definition_list[other_definition_list_number]
-            if definition.confidence > other_definition.confidence then
-              updated_definition_list[other_definition_list_number] = definition
-              updated_definition_index[definition.csname][other_definition_index_number] = definition
-            end
-          end
-          ::next_definition::
-        end
-      end
-      return updated_definition_list, updated_definition_index, current_reaching_statement_index
-    end
-
-    -- Determine whether the reaching definitions after the current statement have changed.
-    local function have_reaching_definitions_changed(chunk, statement_number, updated_definition_list, current_reaching_statement_index)
-      -- Determine the previous set of definitions, if any.
-      if states.results.reaching_definitions.lists[chunk] == nil then
-        return true
-      end
-      if states.results.reaching_definitions.lists[chunk][statement_number] == nil then
-        return true
-      end
-      local previous_definition_list = states.results.reaching_definitions.lists[chunk][statement_number]
-      assert(previous_definition_list ~= nil)
-      assert(#previous_definition_list <= #updated_definition_list)
-
-      -- Quickly check for inequality using set cardinalities.
-      if #previous_definition_list ~= #updated_definition_list then
-        return true
-      end
-
-      -- Check that the definitions and their confidences are the same.
-      for _, previous_definition in ipairs(previous_definition_list) do
-        local statement = get_statement(
-          previous_definition.chunk,
-          previous_definition.macro_statement_number,
-          previous_definition.statement_number
-        )
-        if current_reaching_statement_index[statement] == nil then
-          return true
-        end
-        local updated_definition_list_number, _ = table.unpack(current_reaching_statement_index[statement])
-        local updated_definition = updated_definition_list[updated_definition_list_number]
-        if previous_definition.confidence ~= updated_definition.confidence then
-          return true
-        end
-      end
-
-      return false
-    end
-
     -- Initialize a stack of changed statements to all well-behaved function (variant) definitions.
     local changed_statements_list, changed_statements_index = {}, {}
 
@@ -1121,18 +1117,18 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       local chunk, statement_number = pop_changed_statement()
 
       -- Determine the reaching definitions from before the current statement.
-      local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, statement_number)
+      local incoming_definition_list, incoming_definition_index = get_incoming_definitions(states, chunk, statement_number)
 
       -- Determine the definitions and undefinitions from the current statement.
       local current_definition_list, _, invalidated_statement_index
-        = get_current_definitions(chunk, statement_number, incoming_definition_list, incoming_definition_index)
+        = get_current_definitions(states, chunk, statement_number, incoming_definition_list, incoming_definition_index)
 
       -- Determine the reaching definitions after the current statement.
       local updated_definition_list, updated_definition_index, current_reaching_statement_index
-        = get_outgoing_definitions(incoming_definition_list, current_definition_list, invalidated_statement_index)
+        = get_outgoing_definitions(states, incoming_definition_list, current_definition_list, invalidated_statement_index)
 
       -- Update the stack of changed statements.
-      if have_reaching_definitions_changed(chunk, statement_number, updated_definition_list, current_reaching_statement_index) then
+      if have_reaching_definitions_changed(states, chunk, statement_number, updated_definition_list, current_reaching_statement_index) then
         -- Insert the successive statements into the stack of changed statements.
         for _, out_edge_index in ipairs({states.results.edge_indexes.explicit_out, states.results.edge_indexes.implicit_out}) do
           if out_edge_index[chunk] ~= nil and out_edge_index[chunk][statement_number] ~= nil then
@@ -1175,7 +1171,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
           states.results.reaching_definitions.indexes[function_call_chunk][function_call_statement_number] == nil then
         goto next_function_call
       end
-      local function_call_statement = get_statement(function_call_chunk, function_call_statement_number)
+      local function_call_statement = get_statement(states, function_call_chunk, function_call_statement_number)
       assert(is_well_behaved(function_call_statement))
       local reaching_function_and_variant_definition_list = {}
       local reaching_definition_index = states.results.reaching_definitions.indexes[function_call_chunk][function_call_statement_number]
@@ -1193,7 +1189,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         local definition = reaching_function_and_variant_definition_list[reaching_definition_number]
         local chunk, macro_statement_number, statement_number
           = definition.chunk, definition.macro_statement_number, definition.statement_number
-        local statement = get_statement(chunk, macro_statement_number, statement_number)
+        local statement = get_statement(states, chunk, macro_statement_number, statement_number)
         assert(is_well_behaved(statement))
         -- Detect any loops within the graph.
         if seen_reaching_statements[statement] ~= nil then
@@ -1213,7 +1209,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
             for _, other_definition in ipairs(other_reaching_definition_index[base_csname] or {}) do
               local other_chunk, other_macro_statement_number, other_statement_number
                 = other_definition.chunk, other_definition.macro_statement_number, other_definition.statement_number
-              local other_statement = get_statement(other_chunk, other_macro_statement_number, other_statement_number)
+              local other_statement = get_statement(states, other_chunk, other_macro_statement_number, other_statement_number)
               assert(is_well_behaved(other_statement))
               assert(other_definition.csname == base_csname)
               -- Weaken the base function definition confidence with the function variant definition confidence.
@@ -1237,6 +1233,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       -- Draw the function call edges.
       for _, function_definition in ipairs(reaching_function_definition_list) do
         local function_definition_statement = get_statement(
+          states,
           function_definition.chunk,
           function_definition.macro_statement_number,
           function_definition.statement_number
@@ -1349,9 +1346,9 @@ local function draw_group_wide_dynamic_edges(states, _, options)
 
                 -- Get definitions for a given control sequence name that reach the current statement.
                 local function get_reaching_definitions(csname)
-                  local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, macro_statement_number)
+                  local incoming_definition_list, incoming_definition_index = get_incoming_definitions(states, chunk, macro_statement_number)
                   local current_definition_list, current_definition_index, invalidated_statement_index = get_current_definitions(
-                    chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, statement_number - 1)
+                    states, chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, statement_number - 1)
 
                   local definition_lists = {incoming_definition_list, current_definition_list}
                   local definition_indexes = {incoming_definition_index[csname] or {}, current_definition_index[csname] or {}}
@@ -1373,7 +1370,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                       current_definition_number = current_definition_number + 1
                       local definition = definition_list[definition_number]
                       local other_statement
-                        = get_statement(definition.chunk, definition.macro_statement_number, definition.statement_number)
+                        = get_statement(states, definition.chunk, definition.macro_statement_number, definition.statement_number)
                       if not invalidated_statement_index[other_statement] then
                         return definition
                       end
@@ -1527,7 +1524,7 @@ local function report_issues(states, main_file_number, _)
     local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
     local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #content)
 
-    local statement = get_statement(chunk, statement_number)
+    local statement = get_statement(states, chunk, statement_number)
     assert(not is_macro_statement(statement))
 
     local token_range = call_range_to_token_range(statement.call_range)
@@ -1541,7 +1538,7 @@ local function report_issues(states, main_file_number, _)
     local chunk, statement_number = table.unpack(chunk_and_statement_number)
     if states.results.edge_indexes.function_call[chunk] == nil or
         states.results.edge_indexes.function_call[chunk][statement_number] == nil then
-      local statement = get_statement(chunk, statement_number)
+      local statement = get_statement(states, chunk, statement_number)
       local byte_range = statement_to_byte_range(chunk, statement_number)
       local csname = statement.used_csname
 

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -834,6 +834,31 @@ local function draw_group_wide_dynamic_edges(states, _, options)
 
       -- Pick a statement from the stack of changed statements.
       local chunk, statement_number = pop_changed_statement()
+      local segment = chunk.segment
+
+      local file_number = segment.location.file_number
+      local part_number = segment.location.part_number
+
+      local state = states[file_number]
+
+      local issues = state.issues
+      local results = state.results
+
+      local tokens = results.tokens[part_number]
+
+      -- Get the byte range of a regular (non-macro) statement.
+      local function statement_to_byte_range(...)
+        local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
+        local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
+
+        local statement = _get_statement(chunk, statement_number, ...)
+        assert(not is_macro_statement(statement))
+
+        local token_range = call_range_to_token_range(statement.call_range)
+        local byte_range = token_range_to_byte_range(token_range)
+
+        return byte_range
+      end
 
       -- Collect reaching definitions from the incoming edges.
       local incoming_edge_list = {}
@@ -964,6 +989,11 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                 )
                 assert(incoming_statement.defined_csname.payload == defined_or_undefined_csname)
                 if incoming_statement ~= statement then
+                  if incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition and
+                      statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition then
+                    local byte_range = statement_to_byte_range(statement_number)
+                    issues:add("e500", "multiply defined function", byte_range, format_csname(defined_or_undefined_csname))
+                  end
                   invalidated_statement_index[incoming_statement] = true
                 end
               end

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -989,7 +989,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                 )
                 assert(incoming_statement.defined_csname.payload == defined_or_undefined_csname)
                 if incoming_statement ~= statement then
-                  if incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition and
+                  if invalidated_statement_index[incoming_statement] == nil and
+                      incoming_statement.type == FUNCTION_DEFINITION and not incoming_statement.maybe_redefinition and
                       statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition then
                     local byte_range = statement_to_byte_range(statement_number)
                     issues:add("e500", "multiply defined function", byte_range, format_csname(defined_or_undefined_csname))

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -938,6 +938,44 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       return current_definition_list, invalidated_statement_index
     end
 
+    -- Determine whether the reaching definitions after the current statement have changed.
+    local function have_reaching_definitions_changed(chunk, statement_number, updated_definition_list, current_reaching_statement_index)
+      -- Determine the previous set of definitions, if any.
+      if reaching_definition_lists[chunk] == nil then
+        return true
+      end
+      if reaching_definition_lists[chunk][statement_number] == nil then
+        return true
+      end
+      local previous_definition_list = reaching_definition_lists[chunk][statement_number]
+      assert(previous_definition_list ~= nil)
+      assert(#previous_definition_list <= #updated_definition_list)
+
+      -- Quickly check for inequality using set cardinalities.
+      if #previous_definition_list ~= #updated_definition_list then
+        return true
+      end
+
+      -- Check that the definitions and their confidences are the same.
+      for _, previous_definition in ipairs(previous_definition_list) do
+        local statement = get_statement(
+          previous_definition.chunk,
+          previous_definition.macro_statement_number,
+          previous_definition.statement_number
+        )
+        if current_reaching_statement_index[statement] == nil then
+          return true
+        end
+        local updated_definition_list_number, _ = table.unpack(current_reaching_statement_index[statement])
+        local updated_definition = updated_definition_list[updated_definition_list_number]
+        if previous_definition.confidence ~= updated_definition.confidence then
+          return true
+        end
+      end
+
+      return false
+    end
+
     -- Initialize a stack of changed statements to all well-behaved function (variant) definitions.
     local changed_statements_list, changed_statements_index = {}, {}
 
@@ -1055,46 +1093,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         end
       end
 
-      -- Determine whether the reaching definitions after the current statement have changed.
-      local function have_reaching_definitions_changed()
-        -- Determine the previous set of definitions, if any.
-        if reaching_definition_lists[chunk] == nil then
-          return true
-        end
-        if reaching_definition_lists[chunk][statement_number] == nil then
-          return true
-        end
-        local previous_definition_list = reaching_definition_lists[chunk][statement_number]
-        assert(previous_definition_list ~= nil)
-        assert(#previous_definition_list <= #updated_definition_list)
-
-        -- Quickly check for inequality using set cardinalities.
-        if #previous_definition_list ~= #updated_definition_list then
-          return true
-        end
-
-        -- Check that the definitions and their confidences are the same.
-        for _, previous_definition in ipairs(previous_definition_list) do
-          local statement = get_statement(
-            previous_definition.chunk,
-            previous_definition.macro_statement_number,
-            previous_definition.statement_number
-          )
-          if current_reaching_statement_index[statement] == nil then
-            return true
-          end
-          local updated_definition_list_number, _ = table.unpack(current_reaching_statement_index[statement])
-          local updated_definition = updated_definition_list[updated_definition_list_number]
-          if previous_definition.confidence ~= updated_definition.confidence then
-            return true
-          end
-        end
-
-        return false
-      end
-
       -- Update the stack of changed statements.
-      if have_reaching_definitions_changed() then
+      if have_reaching_definitions_changed(chunk, statement_number, updated_definition_list, current_reaching_statement_index) then
         -- Insert the successive statements into the stack of changed statements.
         for _, out_edge_index in ipairs({explicit_out_edge_index, implicit_out_edge_index}) do
           if out_edge_index[chunk] ~= nil and out_edge_index[chunk][statement_number] ~= nil then

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -603,7 +603,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   local max_reaching_definition_inner_loops = get_option('max_reaching_definition_inner_loops', options)
   local max_reaching_definition_outer_loops = get_option('max_reaching_definition_outer_loops', options)
   local outer_loop_number = 1
-  while true do
+  repeat
     -- Guard against long (infinite?) loops.
     if outer_loop_number > max_reaching_definition_outer_loops then
       error(
@@ -1260,74 +1260,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     end
 
     outer_loop_number = outer_loop_number + 1
-
-    if not any_edges_changed(previous_function_call_edges, current_function_call_edges) then
-      -- After the last outer-loop iteration, report any issues that require the knowledge of the reaching definitions
-      -- and not just the resulting edges before we have freed the corresponding variables.
-      for _, state in ipairs(states) do
-        -- Skip statements from files in the current file group that haven't reached the flow analysis.
-        if state.results.stopped_early then
-          goto next_file
-        end
-        local issues = state.issues
-        for _, segment in ipairs(state.results.segments or {}) do
-          local part_number = segment.location.part_number
-          local tokens = state.results.tokens[part_number]
-          local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
-          for _, chunk in ipairs(segment.chunks or {}) do
-            local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
-            for macro_statement_number, macro_statement in chunk.statement_range:enumerate(segment.macro_statements) do
-              if macro_statement.type ~= FUNCTION_DEFINITIONS then
-                goto next_macro_statement
-              end
-              for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
-                assert(not is_macro_statement(statement))
-                if statement.confidence ~= DEFINITELY or
-                    statement.type ~= FUNCTION_DEFINITION or
-                    statement.maybe_redefinition or
-                    statement.defined_csname.type ~= TEXT then
-                  goto next_statement
-                end
-                if reaching_definition_indexes[chunk] == nil or
-                    reaching_definition_indexes[chunk][macro_statement_number] == nil then
-                  goto next_statement
-                end
-                local reaching_definition_index = reaching_definition_indexes[chunk][macro_statement_number]
-
-                -- Get the byte range of the current statement.
-                local function get_byte_range()
-                  local token_range = call_range_to_token_range(statement.call_range)
-                  local byte_range = token_range_to_byte_range(token_range)
-
-                  return byte_range
-                end
-
-                -- Report multiply defined functions.
-                for _, definition in ipairs(reaching_definition_index[statement.defined_csname.payload] or {}) do
-                  assert(definition.csname == statement.defined_csname.payload)
-                  if definition.confidence ~= DEFINITELY then
-                    goto next_definition
-                  end
-                  if definition.macro_statement_number == macro_statement_number and
-                      definition.statement_number >= statement_number then
-                    -- Exclude the same statement as well as any following statements from the same macro-statement.
-                    goto next_definition
-                  end
-                  issues:add("e500", "multiply defined function", get_byte_range(), format_csname(definition.csname))
-                  ::next_definition::
-                end
-
-                ::next_statement::
-              end
-              ::next_macro_statement::
-            end
-          end
-        end
-        ::next_file::
-      end
-      break
-    end
-  end
+  until not any_edges_changed(previous_function_call_edges, current_function_call_edges)
 
   -- Record edges.
   for _, edge in ipairs(current_function_call_edges) do

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1000,30 +1000,6 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     -- Initialize a stack of changed statements to all well-behaved function (variant) definitions.
     local changed_statements_list, changed_statements_index = {}, {}
 
-    -- Pop a changed statement off the top of stack.
-    local function pop_changed_statement()
-      -- Pick a statement from the stack of changed statements.
-      local chunk_statements = changed_statements_list[#changed_statements_list]
-      local chunk = chunk_statements.chunk
-      local statement_numbers_list = chunk_statements.statement_numbers_list
-      local statement_numbers_index = chunk_statements.statement_numbers_index
-      assert(#statement_numbers_list > 0)
-      local statement_number = statement_numbers_list[#statement_numbers_list]
-
-      -- Remove the statement from the stack.
-      if #statement_numbers_list > 1 then
-        -- If there are remaining statements from the top chunk of the stack, keep the chunk at the stack.
-        table.remove(statement_numbers_list)
-        statement_numbers_index[statement_number] = nil
-      else
-        -- Otherwise, remove the chunk from the stack as well.
-        table.remove(changed_statements_list)
-        changed_statements_index[chunk] = nil
-      end
-
-      return chunk, statement_number
-    end
-
     -- Add a changed statement on the top of the stack.
     local function add_changed_statement(chunk, statement_number)
       -- Get the stack of statements for the given chunk, inserting it if it doesn't exist.
@@ -1047,6 +1023,30 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         table.insert(statement_numbers_list, statement_number)
         statement_numbers_index[statement_number] = #statement_numbers_list
       end
+    end
+
+    -- Pop a changed statement off the top of stack.
+    local function pop_changed_statement()
+      -- Pick a statement from the stack of changed statements.
+      local chunk_statements = changed_statements_list[#changed_statements_list]
+      local chunk = chunk_statements.chunk
+      local statement_numbers_list = chunk_statements.statement_numbers_list
+      local statement_numbers_index = chunk_statements.statement_numbers_index
+      assert(#statement_numbers_list > 0)
+      local statement_number = statement_numbers_list[#statement_numbers_list]
+
+      -- Remove the statement from the stack.
+      if #statement_numbers_list > 1 then
+        -- If there are remaining statements from the top chunk of the stack, keep the chunk at the stack.
+        table.remove(statement_numbers_list)
+        statement_numbers_index[statement_number] = nil
+      else
+        -- Otherwise, remove the chunk from the stack as well.
+        table.remove(changed_statements_list)
+        changed_statements_index[chunk] = nil
+      end
+
+      return chunk, statement_number
     end
 
     for _, chunk_and_statement_number in ipairs(function_definition_list) do
@@ -1276,6 +1276,91 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   end
 end
 
+-- For each segment, determine the minimum reaching nesting depth from other segments.
+local function determine_min_reaching_nesting_depth(states, _, _)
+  -- Determine the minimum reaching nesting depth once for all files in the file group, not just individual files.
+  if states.results.determined_min_reaching_nesting_depth ~= nil then
+    return
+  end
+  states.results.determined_min_reaching_nesting_depth = true
+
+  local changed_segment_list, changed_segment_index = {}, {}
+
+  -- Add a changed segment on the top of the stack.
+  local function add_changed_segment(segment)
+    if changed_segment_index[segment] == nil then
+      table.insert(changed_segment_list, segment)
+      changed_segment_index[segment] = true
+    end
+  end
+
+  -- Pop a changed segment off the top of stack.
+  local function pop_changed_segment()
+    local segment = table.remove(changed_segment_list)
+    changed_segment_index[segment] = nil
+    return segment
+  end
+
+  -- Collect all segments with incoming or outgoing edges and index all these edges.
+  local incoming_edge_index, outgoing_edge_index = {}, {}
+  for _, state in ipairs(states) do
+    -- Skip statements from files in the current file group that haven't reached the flow analysis.
+    if state.results.stopped_early then
+      goto next_file
+    end
+    local edge_category_list = {}
+    for edge_category, _ in pairs(state.results.edges or {}) do
+      table.insert(edge_category_list, edge_category)
+    end
+    table.sort(edge_category_list)
+    for _, edge_category in ipairs(edge_category_list) do
+      local edges = state.results.edges[edge_category]
+      for _, edge in ipairs(edges) do
+        -- Collect the segments with incoming or outgoing edges.
+        for _, segment in ipairs({edge.from.chunk.segment, edge.to.chunk.segment}) do
+          add_changed_segment(segment)
+        end
+        -- Index the edges.
+        for _, segments_and_edge_index in ipairs({
+              {edge.to.chunk.segment, edge.from.chunk.segment, incoming_edge_index},
+              {edge.from.chunk.segment, edge.to.chunk.segment, outgoing_edge_index},
+            }) do
+          local from_segment, to_segment, edge_index = table.unpack(segments_and_edge_index)
+          if edge_index[from_segment] == nil then
+            edge_index[from_segment] = {}
+          end
+          if edge_index[from_segment][to_segment] == nil then
+            table.insert(edge_index[from_segment], to_segment)
+            edge_index[from_segment][to_segment] = true
+          end
+        end
+      end
+    end
+    ::next_file::
+  end
+
+  -- Iterate over the changed statements until convergence.
+  while #changed_segment_list > 0 do
+    -- Pick a sedgment from the stack of changed segments.
+    local segment = pop_changed_segment()
+
+    -- Determine the incoming minimum reaching nesting depth.
+    local min_reaching_nesting_depth = segment.min_reaching_nesting_depth
+    for _, incoming_segment in ipairs(incoming_edge_index[segment] or {}) do
+      min_reaching_nesting_depth = math.min(min_reaching_nesting_depth, incoming_segment.min_reaching_nesting_depth)
+    end
+
+    -- Update the current minimum reaching nesting depth.
+    if min_reaching_nesting_depth < segment.min_reaching_nesting_depth then
+      segment.min_reaching_nesting_depth = min_reaching_nesting_depth
+      -- If there was an update, mark all outgoing segments as changed.
+      for _, outgoing_segment in ipairs(outgoing_edge_index[segment] or {}) do
+        add_changed_segment(outgoing_segment)
+      end
+    end
+  end
+end
+
 -- Report any issues.
 local function report_issues(states, main_file_number, options)
   local state = states[main_file_number]
@@ -1429,9 +1514,9 @@ local function report_issues(states, main_file_number, options)
 
             -- Report setting a function before definition.
             if statement.type == FUNCTION_DEFINITION and statement.maybe_redefinition and statement.defined_csname.type == TEXT
-                -- TODO: Currently, we only consider function calls from within top-level code (`segment.nesting_depth == 1`).
-                -- Ideally, we would consider all function calls that are reachable from top-level code.
-                and segment.nesting_depth == 1 then
+                -- Only consider function calls reachable from top-level code. Otherwise, the calls are part of either dead code
+                -- or library functions and we can't accurately determine the reaching definitions.
+                and segment.min_reaching_nesting_depth == 1 then
               local defined_csname = statement.defined_csname.payload
               if lpeg.match(expl3_well_known_csname, defined_csname) == nil and
                   not any_definite_reaching_definitions(defined_csname) then
@@ -1448,9 +1533,9 @@ local function report_issues(states, main_file_number, options)
           local statement_number, statement = macro_statement_number, macro_statement
           assert(not is_macro_statement(statement))
 
-          -- TODO: Currently, we only consider function calls from within top-level code (`segment.nesting_depth == 1`).
-          -- Ideally, we would consider all function calls that are reachable from top-level code.
-          if segment.nesting_depth > 1 then
+          -- Only consider function calls reachable from top-level code. Otherwise, the calls are part of either dead code
+          -- or library functions and we can't accurately determine the reaching definitions.
+          if segment.min_reaching_nesting_depth > 1 then
             goto next_macro_statement
           end
           if statement.confidence ~= DEFINITELY then
@@ -1500,6 +1585,9 @@ local function cleanup(states, _, _)
   -- Remove group-wide intermediate results.
   states.results.edge_indexes = nil
   states.results.reaching_definitions = nil
+  states.results.drew_static_edges = nil
+  states.results.drew_dynamic_edges = nil
+  states.results.determined_min_reaching_nesting_depth = nil
 end
 
 local substeps = {
@@ -1508,6 +1596,7 @@ local substeps = {
   draw_file_local_static_edges,
   draw_group_wide_static_edges,
   draw_group_wide_dynamic_edges,
+  determine_min_reaching_nesting_depth,
   report_issues,
   cleanup,
 }

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -910,7 +910,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   local max_reaching_definition_inner_loops = get_option('max_reaching_definition_inner_loops', options)
   local max_reaching_definition_outer_loops = get_option('max_reaching_definition_outer_loops', options)
   local outer_loop_number = 1
-  while true do
+  repeat
     -- Guard against long (infinite?) loops.
     if outer_loop_number > max_reaching_definition_outer_loops then
       error(
@@ -1302,143 +1302,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     end
 
     outer_loop_number = outer_loop_number + 1
-
-    if not any_edges_changed(previous_function_call_edges, current_function_call_edges) then
-      -- After the last outer-loop iteration, report any issues that require the knowledge of the reaching definitions
-      -- and not just the resulting edges before we have freed the corresponding variables.
-      for _, state in ipairs(states) do
-        -- Skip statements from files in the current file group that haven't reached the flow analysis.
-        if state.results.stopped_early then
-          goto next_file
-        end
-        local issues = state.issues
-        local imported_prefixes = get_option('imported_prefixes', options, state.pathname)
-        local l3prefixes_max_first_registered_date = get_option("l3prefixes_max_first_registered_date", options, state.pathname)
-        local expl3_well_known_csname = parsers.expl3_well_known_csname(l3prefixes_max_first_registered_date, imported_prefixes)
-        for _, segment in ipairs(state.results.segments or {}) do
-          local part_number = segment.location.part_number
-          local tokens = state.results.tokens[part_number]
-          local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
-          for _, chunk in ipairs(segment.chunks or {}) do
-            local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
-            for macro_statement_number, macro_statement in chunk.statement_range:enumerate(segment.macro_statements) do
-              if macro_statement.type ~= FUNCTION_DEFINITIONS then
-                goto next_macro_statement
-              end
-              for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
-                assert(not is_macro_statement(statement))
-                if statement.confidence ~= DEFINITELY then
-                  goto next_statement
-                end
-
-                -- Get the byte range of the current statement.
-                local function get_byte_range()
-                  local token_range = call_range_to_token_range(statement.call_range)
-                  local byte_range = token_range_to_byte_range(token_range)
-
-                  return byte_range
-                end
-
-                -- Get definitions for a given control sequence name that reach the current statement.
-                local function get_reaching_definitions(csname)
-                  local incoming_definition_list, incoming_definition_index
-                    = get_incoming_definitions(states, chunk, macro_statement_number)
-                  local current_definition_list, current_definition_index, invalidated_statement_index = get_current_definitions(
-                    states, chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, statement_number - 1)
-
-                  local definition_lists = {incoming_definition_list, current_definition_list}
-                  local definition_indexes = {incoming_definition_index[csname] or {}, current_definition_index[csname] or {}}
-                  local current_definition_list_number, current_definition_number = 1, 1
-
-                  return function()
-                    while true do
-                      if current_definition_list_number > #definition_lists then
-                        return nil
-                      end
-                      local definition_list = definition_lists[current_definition_list_number]
-                      local definition_index = definition_indexes[current_definition_list_number]
-                      if current_definition_number > #definition_index then
-                        current_definition_list_number = current_definition_list_number + 1
-                        current_definition_number = 1
-                        goto continue
-                      end
-                      local definition_number = definition_index[current_definition_number]
-                      current_definition_number = current_definition_number + 1
-                      local definition = definition_list[definition_number]
-                      local other_statement
-                        = get_statement(states, definition.chunk, definition.macro_statement_number, definition.statement_number)
-                      if not invalidated_statement_index[other_statement] then
-                        return definition
-                      end
-                      ::continue::
-                    end
-                  end
-                end
-
-                -- Determine whether there are any definite definitions for a given control sequence name that reach the current statement.
-                local function any_definite_reaching_definitions(csname)
-                  if lpeg.match(expl3_well_known_csname, csname) ~= nil then
-                    -- Always consider definitions for well-known expl3 control sequence names to be reaching.
-                    return true
-                  end
-                  for definition in get_reaching_definitions(csname) do
-                    assert(definition.csname == csname)
-                    assert(definition.macro_statement_number <= macro_statement_number)
-                    if definition.macro_statement_number == macro_statement_number then
-                      assert(definition.statement_number < statement_number)
-                    end
-                    if definition.confidence == DEFINITELY then
-                      return true
-                    end
-                  end
-                end
-
-                if (
-                      statement.type == FUNCTION_VARIANT_DEFINITION or
-                      statement.type == FUNCTION_DEFINITION and statement.subtype == FUNCTION_DEFINITION_INDIRECT
-                    ) and statement.base_csname.type == TEXT then
-                  local base_csname = statement.base_csname.payload
-                  if not any_definite_reaching_definitions(base_csname) then
-                    local formatted_csname = format_csname(base_csname)
-                    local byte_range = get_byte_range()
-
-                    -- Report function variants for an undefined function.
-                    if statement.type == FUNCTION_VARIANT_DEFINITION then
-                      issues:add("e504", "function variant for an undefined function", byte_range, formatted_csname)
-                    -- Report indirect function definitions from an undefined function.
-                    elseif statement.type == FUNCTION_DEFINITION then
-                      assert(statement.subtype == FUNCTION_DEFINITION_INDIRECT)
-                      issues:add("e506", "indirect function definition from an undefined function", byte_range, formatted_csname)
-                    else
-                      error('Unexpected statement type "' .. statement.type .. '" and subtype "' .. statement.subtype .. '"')
-                    end
-                  end
-                end
-
-                -- Report setting a function before definition.
-                if statement.type == FUNCTION_DEFINITION and statement.maybe_redefinition and statement.defined_csname.type == TEXT
-                    -- TODO: Currently, we only consider function calls from within top-level code (`segment.nesting_depth == 1`).
-                    -- Ideally, we would consider all function calls that are reachable from top-level code.
-                    and segment.nesting_depth == 1 then
-                  local defined_csname = statement.defined_csname.payload
-                  if not any_definite_reaching_definitions(defined_csname) then
-                    local formatted_csname = format_csname(defined_csname)
-                    local byte_range = get_byte_range()
-                    issues:add("w507", "setting a function before definition", byte_range, formatted_csname)
-                  end
-                end
-
-                ::next_statement::
-              end
-              ::next_macro_statement::
-            end
-          end
-        end
-        ::next_file::
-      end
-      break
-    end
-  end
+  until not any_edges_changed(previous_function_call_edges, current_function_call_edges)
 
   -- Record edges.
   states.results.edge_indexes.function_call = {}
@@ -1454,64 +1318,177 @@ local function draw_group_wide_dynamic_edges(states, _, options)
 end
 
 -- Report any issues.
-local function report_issues(states, main_file_number, _)
+local function report_issues(states, main_file_number, options)
   local state = states[main_file_number]
 
   local issues = state.issues
 
-  -- Report calling an undefined function.
-  --
-  -- TODO: Currently, we only consider function calls from within top-level code (`state.results.parts`).
-  -- Ideally, we would consider all function calls (`state.results.segments`) that are reachable from top-level code.
-  for part_number, segment in ipairs(state.results.parts or {}) do
-    assert(part_number == segment.location.part_number)
+  local imported_prefixes = get_option('imported_prefixes', options, state.pathname)
+  local l3prefixes_max_first_registered_date = get_option("l3prefixes_max_first_registered_date", options, state.pathname)
+  local expl3_well_known_csname = parsers.expl3_well_known_csname(l3prefixes_max_first_registered_date, imported_prefixes)
+
+  for _, segment in ipairs(state.results.segments or {}) do
+    local part_number = segment.location.part_number
     local tokens = state.results.tokens[part_number]
     local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
     for _, chunk in ipairs(segment.chunks or {}) do
       local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
-      for statement_number, statement in chunk.statement_range:enumerate(segment.macro_statements) do
-        if statement.type ~= FUNCTION_CALL then
-          goto next_statement
-        end
-        if statement.confidence ~= DEFINITELY then
-          goto next_statement
-        end
-        if not is_well_behaved(statement) then
-          goto next_statement
-        end
+      for macro_statement_number, macro_statement in chunk.statement_range:enumerate(segment.macro_statements) do
+        -- Report issues with function (variant) (un)definitions.
+        if macro_statement.type == FUNCTION_DEFINITIONS then
+          for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
+            assert(not is_macro_statement(statement))
+            if statement.confidence ~= DEFINITELY then
+              goto next_statement
+            end
 
-        assert(not is_macro_statement(statement))
+            -- Get the byte range of the current statement.
+            local function get_byte_range()
+              local token_range = call_range_to_token_range(statement.call_range)
+              local byte_range = token_range_to_byte_range(token_range)
 
-        -- Get the byte range of the current statement.
-        local function get_byte_range()
-          local token_range = call_range_to_token_range(statement.call_range)
-          local byte_range = token_range_to_byte_range(token_range)
+              return byte_range
+            end
 
-          return byte_range
-        end
+            -- Get definitions for a given control sequence name that reach the current statement.
+            local function get_reaching_definitions(csname)
+              local incoming_definition_list, incoming_definition_index
+                = get_incoming_definitions(states, chunk, macro_statement_number)
+              local current_definition_list, current_definition_index, invalidated_statement_index = get_current_definitions(
+                states, chunk, macro_statement_number, incoming_definition_list, incoming_definition_index, statement_number - 1)
 
-        assert(statement.definition_file_numbers ~= nil)
-        assert(#statement.definition_file_numbers > 0)
-        local all_definitions_reached_flow_analysis = true
-        for _, file_number in ipairs(statement.definition_file_numbers) do
-          -- Do not check statements originating from files that did not reach the flow analysis.
-          if states[file_number].results.stopped_early then
-            all_definitions_reached_flow_analysis = false
-            break
+              local definition_lists = {incoming_definition_list, current_definition_list}
+              local definition_indexes = {incoming_definition_index[csname] or {}, current_definition_index[csname] or {}}
+              local current_definition_list_number, current_definition_number = 1, 1
+
+              return function()
+                while true do
+                  if current_definition_list_number > #definition_lists then
+                    return nil
+                  end
+                  local definition_list = definition_lists[current_definition_list_number]
+                  local definition_index = definition_indexes[current_definition_list_number]
+                  if current_definition_number > #definition_index then
+                    current_definition_list_number = current_definition_list_number + 1
+                    current_definition_number = 1
+                    goto continue
+                  end
+                  local definition_number = definition_index[current_definition_number]
+                  current_definition_number = current_definition_number + 1
+                  local definition = definition_list[definition_number]
+                  local other_statement
+                    = get_statement(states, definition.chunk, definition.macro_statement_number, definition.statement_number)
+                  if not invalidated_statement_index[other_statement] then
+                    return definition
+                  end
+                  ::continue::
+                end
+              end
+            end
+
+            -- Determine whether there are any definite definitions for a given control sequence name that reach the current statement.
+            local function any_definite_reaching_definitions(csname)
+              if lpeg.match(expl3_well_known_csname, csname) ~= nil then
+                -- Always consider definitions for well-known expl3 control sequence names to be reaching.
+                return true
+              end
+              for definition in get_reaching_definitions(csname) do
+                assert(definition.csname == csname)
+                assert(definition.macro_statement_number <= macro_statement_number)
+                if definition.macro_statement_number == macro_statement_number then
+                  assert(definition.statement_number < statement_number)
+                end
+                if definition.confidence == DEFINITELY then
+                  return true
+                end
+              end
+            end
+
+            if (
+                  statement.type == FUNCTION_VARIANT_DEFINITION or
+                  statement.type == FUNCTION_DEFINITION and statement.subtype == FUNCTION_DEFINITION_INDIRECT
+                ) and statement.base_csname.type == TEXT then
+              local base_csname = statement.base_csname.payload
+              if not any_definite_reaching_definitions(base_csname) then
+                local formatted_csname = format_csname(base_csname)
+                local byte_range = get_byte_range()
+
+                -- Report function variants for an undefined function.
+                if statement.type == FUNCTION_VARIANT_DEFINITION then
+                  issues:add("e504", "function variant for an undefined function", byte_range, formatted_csname)
+                -- Report indirect function definitions from an undefined function.
+                elseif statement.type == FUNCTION_DEFINITION then
+                  assert(statement.subtype == FUNCTION_DEFINITION_INDIRECT)
+                  issues:add("e506", "indirect function definition from an undefined function", byte_range, formatted_csname)
+                else
+                  error('Unexpected statement type "' .. statement.type .. '" and subtype "' .. statement.subtype .. '"')
+                end
+              end
+            end
+
+            -- Report setting a function before definition.
+            if statement.type == FUNCTION_DEFINITION and statement.maybe_redefinition and statement.defined_csname.type == TEXT
+                -- TODO: Currently, we only consider function calls from within top-level code (`segment.nesting_depth == 1`).
+                -- Ideally, we would consider all function calls that are reachable from top-level code.
+                and segment.nesting_depth == 1 then
+              local defined_csname = statement.defined_csname.payload
+              if not any_definite_reaching_definitions(defined_csname) then
+                local formatted_csname = format_csname(defined_csname)
+                local byte_range = get_byte_range()
+                issues:add("w507", "setting a function before definition", byte_range, formatted_csname)
+              end
+            end
+
+            ::next_statement::
+          end
+        -- Report calling an undefined function.
+        elseif macro_statement.type == FUNCTION_CALL then
+          local statement_number, statement = macro_statement_number, macro_statement
+          assert(not is_macro_statement(statement))
+
+          -- TODO: Currently, we only consider function calls from within top-level code (`segment.nesting_depth == 1`).
+          -- Ideally, we would consider all function calls that are reachable from top-level code.
+          if segment.nesting_depth > 1 then
+            goto next_macro_statement
+          end
+          if statement.confidence ~= DEFINITELY then
+            goto next_macro_statement
+          end
+          if not is_well_behaved(statement) then
+            goto next_macro_statement
+          end
+
+          -- Get the byte range of the current statement.
+          local function get_byte_range()
+            local token_range = call_range_to_token_range(statement.call_range)
+            local byte_range = token_range_to_byte_range(token_range)
+
+            return byte_range
+          end
+
+          assert(statement.definition_file_numbers ~= nil)
+          assert(#statement.definition_file_numbers > 0)
+          local all_definitions_reached_flow_analysis = true
+          for _, file_number in ipairs(statement.definition_file_numbers) do
+            -- Do not check statements originating from files that did not reach the flow analysis.
+            if states[file_number].results.stopped_early then
+              all_definitions_reached_flow_analysis = false
+              break
+            end
+          end
+          if all_definitions_reached_flow_analysis then
+            if states.results.edge_indexes.function_call[chunk] == nil or
+                states.results.edge_indexes.function_call[chunk][statement_number] == nil then
+              local formatted_csname = format_csname(statement.used_csname)
+              local byte_range = get_byte_range()
+              issues:add("e505", "calling an undefined function", byte_range, formatted_csname)
+            else
+              assert(#states.results.edge_indexes.function_call[chunk][statement_number] > 0)
+            end
           end
         end
-        if all_definitions_reached_flow_analysis then
-          if states.results.edge_indexes.function_call[chunk] == nil or
-              states.results.edge_indexes.function_call[chunk][statement_number] == nil then
-            local formatted_csname = format_csname(statement.used_csname)
-            local byte_range = get_byte_range()
-            issues:add("e505", "calling an undefined function", byte_range, formatted_csname)
-          else
-            assert(#states.results.edge_indexes.function_call[chunk][statement_number] > 0)
-          end
-        end
-        ::next_statement::
       end
+      ::next_macro_statement::
     end
   end
 end

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1316,7 +1316,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                   return byte_range
                 end
 
-                -- Get definitions that reach the current statement
+                -- Get definitions for a given control sequence name that reach the current statement.
                 local function get_reaching_definitions(csname)
                   local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, macro_statement_number)
                   local current_definition_list, current_definition_index, invalidated_statement_index = get_current_definitions(
@@ -1351,45 +1351,53 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                   end
                 end
 
-                if (statement.type ~= FUNCTION_VARIANT_DEFINITION) and
-                    (statement.type ~= FUNCTION_DEFINITION or statement.subtype ~= FUNCTION_DEFINITION_INDIRECT) then
-                  goto next_statement
-                end
-                if statement.base_csname.type ~= TEXT then
-                  goto next_statement
-                end
-
-                local any_definitions = false
-                for definition in get_reaching_definitions(statement.base_csname.payload) do
-                  assert(definition.csname == statement.base_csname.payload)
-                  assert(definition.macro_statement_number <= macro_statement_number)
-                  if definition.macro_statement_number == macro_statement_number then
-                    assert(definition.statement_number < statement_number)
-                  end
-                  if definition.confidence ~= DEFINITELY then
-                    goto next_definition
-                  end
-                  any_definitions = true
-                  goto skip_following_definitions
-                  ::next_definition::
-                end
-                ::skip_following_definitions::
-
-                if not any_definitions then
-                  local formatted_csname = format_csname(statement.base_csname.payload)
-                  local byte_range = get_byte_range()
-
-                  -- Report function variants for an undefined function.
-                  if statement.type == FUNCTION_VARIANT_DEFINITION then
-                    issues:add("e504", "function variant for an undefined function", byte_range, formatted_csname)
-                  -- Report indirect function definitions from an undefined function.
-                  elseif statement.type == FUNCTION_DEFINITION then
-                    assert(statement.subtype == FUNCTION_DEFINITION_INDIRECT)
-                    issues:add("e506", "indirect function definition from an undefined function", byte_range, formatted_csname)
-                  else
-                    error('Unexpected statement type "' .. statement.type .. '" and subtype "' .. statement.subtype .. '"')
+                -- Determine whether there are any definite definitions for a given control sequence name that reach the current statement.
+                local function any_definite_reaching_definitions(csname)
+                  for definition in get_reaching_definitions(csname) do
+                    assert(definition.csname == statement.base_csname.payload)
+                    assert(definition.macro_statement_number <= macro_statement_number)
+                    if definition.macro_statement_number == macro_statement_number then
+                      assert(definition.statement_number < statement_number)
+                    end
+                    if definition.confidence == DEFINITELY then
+                      return true
+                    end
                   end
                 end
+
+                if (
+                      statement.type == FUNCTION_VARIANT_DEFINITION or
+                      statement.type == FUNCTION_DEFINITION and statement.subtype == FUNCTION_DEFINITION_INDIRECT
+                    ) and statement.base_csname.type == TEXT then
+                  if not any_definite_reaching_definitions(statement.base_csname.payload) then
+                    local formatted_csname = format_csname(statement.base_csname.payload)
+                    local byte_range = get_byte_range()
+
+                    -- Report function variants for an undefined function.
+                    if statement.type == FUNCTION_VARIANT_DEFINITION then
+                      issues:add("e504", "function variant for an undefined function", byte_range, formatted_csname)
+                    -- Report indirect function definitions from an undefined function.
+                    elseif statement.type == FUNCTION_DEFINITION then
+                      assert(statement.subtype == FUNCTION_DEFINITION_INDIRECT)
+                      issues:add("e506", "indirect function definition from an undefined function", byte_range, formatted_csname)
+                    else
+                      error('Unexpected statement type "' .. statement.type .. '" and subtype "' .. statement.subtype .. '"')
+                    end
+                  end
+                end
+
+                -- Report setting a function before definition.
+                if statement.type == FUNCTION_DEFINITION and statement.maybe_redefinition and statement.defined_csname.type == TEXT
+                    -- TODO: Currently, we only consider function calls from within top-level code (`segment.nesting_depth == 1`).
+                    -- Ideally, we would consider all function calls that are reachable from top-level code.
+                    and segment.nesting_depth == 1 then
+                  if not any_definite_reaching_definitions(statement.defined_csname.payload) then
+                    local formatted_csname = format_csname(statement.defined_csname.payload)
+                    local byte_range = get_byte_range()
+                    issues:add("w507", "setting a function before definition", byte_range, formatted_csname)
+                  end
+                end
+
                 ::next_statement::
               end
               ::next_macro_statement::

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -510,7 +510,7 @@ local function any_edges_changed(first_edges, second_edges)
 end
 
 -- Index an edge in an edge index.
-local function _index_edge(states, edge_index_name, index_key, edge)
+local function index_edge(states, edge_index_name, index_key, edge)
   assert(not states[edge.from.chunk.segment.location.file_number].results.stopped_early)
   assert(not states[edge.to.chunk.segment.location.file_number].results.stopped_early)
   local edge_index = states.results.edge_indexes[edge_index_name]
@@ -852,11 +852,6 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   end
   states.results.drew_dynamic_edges = true
 
-  -- Index an edge in an edge index.
-  local function index_edge(edge_index, index_key, edge)
-    return _index_edge(states, edge_index, index_key, edge)
-  end
-
   -- Check whether a statement is "interesting". A statement is interesting if it has the potential to consume or affect
   -- the reaching definitions other than just passing along the definitions from the previous statement in the chunk.
   local function is_interesting(chunk, macro_statement_number)
@@ -954,8 +949,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
     end
     for _, edges in ipairs(edge_lists) do
       for _, edge in ipairs(edges) do
-        index_edge('explicit_in', 'to', edge)
-        index_edge('explicit_out', 'from', edge)
+        index_edge(states, 'explicit_in', 'to', edge)
+        index_edge(states, 'explicit_out', 'from', edge)
       end
     end
 
@@ -987,8 +982,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
                 },
                 confidence = edge_confidence,
               }
-              index_edge('implicit_in', 'to', edge)
-              index_edge('implicit_out', 'from', edge)
+              index_edge(states, 'implicit_in', 'to', edge)
+              index_edge(states, 'implicit_out', 'from', edge)
             end
             previous_interesting_statement_number = statement_number
             edge_confidence = DEFINITELY
@@ -1446,6 +1441,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   end
 
   -- Record edges.
+  states.results.edge_indexes.function_call = {}
   for _, edge in ipairs(current_function_call_edges) do
     local results = states[edge.from.chunk.segment.location.file_number].results
     assert(results.edges ~= nil)
@@ -1453,6 +1449,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       results.edges[DYNAMIC] = {}
     end
     table.insert(results.edges[DYNAMIC], edge)
+    index_edge(states, 'function_call', 'from', edge)
   end
 end
 
@@ -1460,23 +1457,18 @@ end
 local function report_issues(states, main_file_number, _)
   local state = states[main_file_number]
 
-  local content = state.content
-  local results = state.results
-  assert(results.edges ~= nil)
-
   local issues = state.issues
 
-  -- Index an edge in an edge index.
-  local function index_edge(edge_index, index_key, edge)
-    return _index_edge(states, edge_index, index_key, edge)
-  end
-
-  -- Collect a list of well-behaved function call statements.
-  local definite_function_call_list = {}
-  -- TODO: Currently, we only consider function calls from within top-level code (`results.parts`).
-  -- Ideally, we would consider all function calls (`results.segments`) that are reachable from top-level code.
-  for _, segment in ipairs(results.parts or {}) do
+  -- Report calling an undefined function.
+  --
+  -- TODO: Currently, we only consider function calls from within top-level code (`state.results.parts`).
+  -- Ideally, we would consider all function calls (`state.results.segments`) that are reachable from top-level code.
+  for part_number, segment in ipairs(state.results.parts or {}) do
+    assert(part_number == segment.location.part_number)
+    local tokens = state.results.tokens[part_number]
+    local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
     for _, chunk in ipairs(segment.chunks or {}) do
+      local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
       for statement_number, statement in chunk.statement_range:enumerate(segment.macro_statements) do
         if statement.type ~= FUNCTION_CALL then
           goto next_statement
@@ -1487,65 +1479,39 @@ local function report_issues(states, main_file_number, _)
         if not is_well_behaved(statement) then
           goto next_statement
         end
-        -- Do not check statements originating from files that did not reach the flow analysis.
+
+        assert(not is_macro_statement(statement))
+
+        -- Get the byte range of the current statement.
+        local function get_byte_range()
+          local token_range = call_range_to_token_range(statement.call_range)
+          local byte_range = token_range_to_byte_range(token_range)
+
+          return byte_range
+        end
+
         assert(statement.definition_file_numbers ~= nil)
         assert(#statement.definition_file_numbers > 0)
         local all_definitions_reached_flow_analysis = true
         for _, file_number in ipairs(statement.definition_file_numbers) do
+          -- Do not check statements originating from files that did not reach the flow analysis.
           if states[file_number].results.stopped_early then
             all_definitions_reached_flow_analysis = false
             break
           end
         end
         if all_definitions_reached_flow_analysis then
-          table.insert(definite_function_call_list, {chunk, statement_number})
+          if states.results.edge_indexes.function_call[chunk] == nil or
+              states.results.edge_indexes.function_call[chunk][statement_number] == nil then
+            local formatted_csname = format_csname(statement.used_csname)
+            local byte_range = get_byte_range()
+            issues:add("e505", "calling an undefined function", byte_range, formatted_csname)
+          else
+            assert(#states.results.edge_indexes.function_call[chunk][statement_number] > 0)
+          end
         end
         ::next_statement::
       end
-    end
-  end
-
-  -- Collect a list of function call edges.
-  states.results.edge_indexes.function_call = {}
-  for _, edge in ipairs(results.edges[DYNAMIC] or {}) do
-    if edge.type == FUNCTION_CALL then
-      index_edge('function_call', 'from', edge)
-    end
-  end
-
-  -- Get the byte range of a regular (non-macro) statement.
-  local function statement_to_byte_range(chunk, statement_number)
-    local segment = chunk.segment
-    assert(segment.location.file_number == main_file_number)
-
-    local part_number = segment.location.part_number
-
-    local tokens = results.tokens[part_number]
-
-    local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
-    local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #content)
-
-    local statement = get_statement(states, chunk, statement_number)
-    assert(not is_macro_statement(statement))
-
-    local token_range = call_range_to_token_range(statement.call_range)
-    local byte_range = token_range_to_byte_range(token_range)
-
-    return byte_range
-  end
-
-  -- Report calling an undefined function.
-  for _, chunk_and_statement_number in ipairs(definite_function_call_list) do
-    local chunk, statement_number = table.unpack(chunk_and_statement_number)
-    if states.results.edge_indexes.function_call[chunk] == nil or
-        states.results.edge_indexes.function_call[chunk][statement_number] == nil then
-      local statement = get_statement(states, chunk, statement_number)
-      local byte_range = statement_to_byte_range(chunk, statement_number)
-      local csname = statement.used_csname
-
-      issues:add("e505", "calling an undefined function", byte_range, format_csname(csname.transcript))
-    else
-      assert(#states.results.edge_indexes.function_call[chunk][statement_number] > 0)
     end
   end
 end

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -824,79 +824,8 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       return incoming_definition_list, incoming_definition_index
     end
 
-    -- Initialize a stack of changed statements to all well-behaved function (variant) definitions.
-    local changed_statements_list, changed_statements_index = {}, {}
-
-    -- Pop a changed statement off the top of stack.
-    local function pop_changed_statement()
-      -- Pick a statement from the stack of changed statements.
-      local chunk_statements = changed_statements_list[#changed_statements_list]
-      local chunk = chunk_statements.chunk
-      local statement_numbers_list = chunk_statements.statement_numbers_list
-      local statement_numbers_index = chunk_statements.statement_numbers_index
-      assert(#statement_numbers_list > 0)
-      local statement_number = statement_numbers_list[#statement_numbers_list]
-
-      -- Remove the statement from the stack.
-      if #statement_numbers_list > 1 then
-        -- If there are remaining statements from the top chunk of the stack, keep the chunk at the stack.
-        table.remove(statement_numbers_list)
-        statement_numbers_index[statement_number] = nil
-      else
-        -- Otherwise, remove the chunk from the stack as well.
-        table.remove(changed_statements_list)
-        changed_statements_index[chunk] = nil
-      end
-
-      return chunk, statement_number
-    end
-
-    -- Add a changed statement on the top of the stack.
-    local function add_changed_statement(chunk, statement_number)
-      -- Get the stack of statements for the given chunk, inserting it if it doesn't exist.
-      local chunk_statements
-      if changed_statements_index[chunk] == nil then
-        chunk_statements = {
-          chunk = chunk,
-          statement_numbers_list = {},
-          statement_numbers_index = {},
-        }
-        table.insert(changed_statements_list, chunk_statements)
-        changed_statements_index[chunk] = #changed_statements_list
-      else
-        chunk_statements = changed_statements_list[changed_statements_index[chunk]]
-      end
-
-      -- Insert the statement to the stack if it isn't there already.
-      local statement_numbers_list = chunk_statements.statement_numbers_list
-      local statement_numbers_index = chunk_statements.statement_numbers_index
-      if statement_numbers_index[statement_number] == nil then
-        table.insert(statement_numbers_list, statement_number)
-        statement_numbers_index[statement_number] = #statement_numbers_list
-      end
-    end
-
-    for _, chunk_and_statement_number in ipairs(function_definition_list) do
-      local chunk, statement_number = table.unpack(chunk_and_statement_number)
-      add_changed_statement(chunk, statement_number)
-    end
-
-    -- Iterate over the changed statements until convergence.
-    local inner_loop_number = 1
-    while #changed_statements_list > 0 do
-      -- Guard against long (infinite?) loops.
-      if inner_loop_number > max_reaching_definition_inner_loops then
-        error(
-          string.format(
-            "Reaching definitions took more than %d inner loops, try increasing the `max_reaching_definition_inner_loops` Lua option",
-            max_reaching_definition_inner_loops
-          )
-        )
-      end
-
-      -- Pick a statement from the stack of changed statements.
-      local chunk, statement_number = pop_changed_statement()
-
+    -- Determine the definitions and undefinitions from the current statement.
+    local function get_current_definitions(chunk, macro_statement_number, incoming_definition_list, incoming_definition_index)
       local segment = chunk.segment
       local file_number = segment.location.file_number
       local state = states[file_number]
@@ -904,14 +833,14 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       local issues = state.issues
 
       -- Get the byte range of a regular (non-macro) statement.
-      local function statement_to_byte_range(...)
+      local function statement_to_byte_range(statement_number)
         local part_number = segment.location.part_number
         local tokens = state.results.tokens[part_number]
 
         local token_range_to_byte_range = get_token_range_to_byte_range(tokens, #state.content)
         local call_range_to_token_range = get_call_range_to_token_range(chunk.segment.calls, #tokens)
 
-        local statement = _get_statement(chunk, statement_number, ...)
+        local statement = _get_statement(chunk, macro_statement_number, statement_number)
         assert(not is_macro_statement(statement))
 
         local token_range = call_range_to_token_range(statement.call_range)
@@ -920,30 +849,14 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         return byte_range
       end
 
-      -- Collect reaching definitions from the incoming edges.
-      local incoming_edge_list = {}
-      for _, in_edge_index in ipairs({explicit_in_edge_index, implicit_in_edge_index}) do
-        if in_edge_index[chunk] ~= nil and in_edge_index[chunk][statement_number] ~= nil then
-          for _, edge in ipairs(in_edge_index[chunk][statement_number]) do
-            table.insert(incoming_edge_list, edge)
-          end
-        end
-      end
-
-      -- Determine the reaching definitions from before the current statement.
-      local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, statement_number)
-
-      -- Determine the definitions and undefinitions from the current statement.
       local current_definition_list, current_definition_index = {}, {}
       local invalidated_statement_index = {}
-      if statement_number <= chunk.statement_range:stop() then  -- Unless this is a pseudo-statement "after" a chunk.
-        local macro_statement_number = statement_number
+      if macro_statement_number <= chunk.statement_range:stop() then  -- Unless this is a pseudo-statement "after" a chunk.
         local macro_statement = get_statement(chunk, macro_statement_number)
         if macro_statement.type ~= FUNCTION_DEFINITIONS then
           goto next_macro_statement
         end
-        ---@diagnostic disable-next-line:redefined-local
-        for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do  -- luacheck: ignore
+        for statement_number, statement in ipairs(macro_statement.statements or {macro_statement}) do
           assert(not is_macro_statement(statement))
           if statement.type ~= FUNCTION_DEFINITION and
               statement.type ~= FUNCTION_UNDEFINITION and
@@ -1022,6 +935,88 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         end
         ::next_macro_statement::
       end
+      return current_definition_list, invalidated_statement_index
+    end
+
+    -- Initialize a stack of changed statements to all well-behaved function (variant) definitions.
+    local changed_statements_list, changed_statements_index = {}, {}
+
+    -- Pop a changed statement off the top of stack.
+    local function pop_changed_statement()
+      -- Pick a statement from the stack of changed statements.
+      local chunk_statements = changed_statements_list[#changed_statements_list]
+      local chunk = chunk_statements.chunk
+      local statement_numbers_list = chunk_statements.statement_numbers_list
+      local statement_numbers_index = chunk_statements.statement_numbers_index
+      assert(#statement_numbers_list > 0)
+      local statement_number = statement_numbers_list[#statement_numbers_list]
+
+      -- Remove the statement from the stack.
+      if #statement_numbers_list > 1 then
+        -- If there are remaining statements from the top chunk of the stack, keep the chunk at the stack.
+        table.remove(statement_numbers_list)
+        statement_numbers_index[statement_number] = nil
+      else
+        -- Otherwise, remove the chunk from the stack as well.
+        table.remove(changed_statements_list)
+        changed_statements_index[chunk] = nil
+      end
+
+      return chunk, statement_number
+    end
+
+    -- Add a changed statement on the top of the stack.
+    local function add_changed_statement(chunk, statement_number)
+      -- Get the stack of statements for the given chunk, inserting it if it doesn't exist.
+      local chunk_statements
+      if changed_statements_index[chunk] == nil then
+        chunk_statements = {
+          chunk = chunk,
+          statement_numbers_list = {},
+          statement_numbers_index = {},
+        }
+        table.insert(changed_statements_list, chunk_statements)
+        changed_statements_index[chunk] = #changed_statements_list
+      else
+        chunk_statements = changed_statements_list[changed_statements_index[chunk]]
+      end
+
+      -- Insert the statement to the stack if it isn't there already.
+      local statement_numbers_list = chunk_statements.statement_numbers_list
+      local statement_numbers_index = chunk_statements.statement_numbers_index
+      if statement_numbers_index[statement_number] == nil then
+        table.insert(statement_numbers_list, statement_number)
+        statement_numbers_index[statement_number] = #statement_numbers_list
+      end
+    end
+
+    for _, chunk_and_statement_number in ipairs(function_definition_list) do
+      local chunk, statement_number = table.unpack(chunk_and_statement_number)
+      add_changed_statement(chunk, statement_number)
+    end
+
+    -- Iterate over the changed statements until convergence.
+    local inner_loop_number = 1
+    while #changed_statements_list > 0 do
+      -- Guard against long (infinite?) loops.
+      if inner_loop_number > max_reaching_definition_inner_loops then
+        error(
+          string.format(
+            "Reaching definitions took more than %d inner loops, try increasing the `max_reaching_definition_inner_loops` Lua option",
+            max_reaching_definition_inner_loops
+          )
+        )
+      end
+
+      -- Pick a statement from the stack of changed statements.
+      local chunk, statement_number = pop_changed_statement()
+
+      -- Determine the reaching definitions from before the current statement.
+      local incoming_definition_list, incoming_definition_index = get_incoming_definitions(chunk, statement_number)
+
+      -- Determine the definitions and undefinitions from the current statement.
+      local current_definition_list, invalidated_statement_index
+        = get_current_definitions(chunk, statement_number, incoming_definition_list, incoming_definition_index)
 
       -- Determine the reaching definitions after the current statement.
       local updated_definition_list, updated_definition_index = {}, {}

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -925,6 +925,7 @@ local function collect_statements(states, file_number, options)
                 defined_csname_argument = defined_csname_argument,
                 definition_token_range = definition_token_range,
                 maybe_called = false,
+                maybe_multiply_defined = false,
                 -- The following attributes are specific to the subtype.
                 is_conditional = is_conditional,
                 is_protected = is_protected,
@@ -1001,6 +1002,7 @@ local function collect_statements(states, file_number, options)
                 defined_csname_argument = defined_csname_argument,
                 definition_token_range = token_range,
                 maybe_called = false,
+                maybe_multiply_defined = false,
                 -- The following attributes are specific to the subtype.
                 base_csname = effective_base_csname,
                 is_conditional = is_conditional,
@@ -1404,6 +1406,7 @@ local function analyze_group_wide_statements(states, _, options)
 
     -- Index group-wide statements.
     function_definition_index = {},
+    non_redefined_function_definition_index = {},
   }
 
   -- Collect all segments of top-level and nested tokens, calls, and statements from all files within the group.
@@ -1444,6 +1447,7 @@ local function analyze_group_wide_statements(states, _, options)
 
       -- Index file-local statements.
       function_call_list = {},
+      non_redefined_function_definition_list = {},
     }
     for _, segment in ipairs(results.segments or {}) do
       assert(file_number == segment.location.file_number)
@@ -1754,6 +1758,16 @@ local function analyze_group_wide_statements(states, _, options)
               states.results.statement_analysis.function_definition_index[statement.defined_csname.payload] = {}
             end
             table.insert(states.results.statement_analysis.function_definition_index[statement.defined_csname.payload], statement)
+            if not statement.maybe_redefined then
+              if states.results.statement_analysis.non_redefined_function_definition_index[statement.defined_csname.payload] == nil then
+                states.results.statement_analysis.non_redefined_function_definition_index[statement.defined_csname.payload] = {}
+              end
+              table.insert(
+                states.results.statement_analysis.non_redefined_function_definition_index[statement.defined_csname.payload],
+                statement
+              )
+              table.insert(results.statement_analysis.non_redefined_function_definition_list, statement)
+            end
           end
         -- Process a function undefinition.
         elseif statement.type == FUNCTION_UNDEFINITION then
@@ -2098,7 +2112,9 @@ local function report_issues(states, file_number, options)
         end
       end
       -- Index the function call.
-      table.insert(results.statement_analysis.function_call_list, statement)
+      if statement.used_csname.type == TEXT then
+        table.insert(results.statement_analysis.function_call_list, statement)
+      end
     end
   end
 
@@ -2278,7 +2294,7 @@ end
 
 -- Determine which function (variant) (un)definitions might actually affect any function calls in the current file group.
 -- This information is used to exclude definitely unused (un)definitions from future analyses to improve performance.
-local function determine_used_function_definitions(states, file_number, _)
+local function determine_maybe_used_function_definitions(states, file_number, _)
   assert(states.results.statement_analysis ~= nil)
 
   local state = states[file_number]
@@ -2290,9 +2306,8 @@ local function determine_used_function_definitions(states, file_number, _)
   local function_and_variant_definitions_and_undefinition_list = {}
   local seen_used_csnames = {}
   for _, statement in ipairs(results.statement_analysis.function_call_list) do
-    if statement.used_csname.type ~= TEXT then
-      goto next_statement
-    end
+    assert(statement.type == FUNCTION_CALL)
+    assert(statement.used_csname.type == TEXT)
     local used_csname = statement.used_csname.payload
     -- Do not repeatedly check the same calls.
     if seen_used_csnames[used_csname] ~= nil then
@@ -2352,6 +2367,29 @@ local function determine_used_function_definitions(states, file_number, _)
   end
 end
 
+-- Determine which function definitions might be multiply defined.
+local function determine_maybe_multiply_defined_function_definitions(states, file_number, _)
+  assert(states.results.statement_analysis ~= nil)
+
+  local state = states[file_number]
+
+  local results = state.results
+  assert(results.statement_analysis ~= nil)
+
+  -- For each non-redefining function definition, check if other non-redefining definitions exist.
+  for _, statement in ipairs(results.statement_analysis.non_redefined_function_definition_list) do
+    assert(statement.type == FUNCTION_DEFINITION)
+    assert(statement.defined_csname.type == TEXT)
+    local defined_csname = statement.defined_csname.payload
+    local other_statements = states.results.statement_analysis.non_redefined_function_definition_index[defined_csname]
+    if #other_statements > 1 then
+      for _, other_statement in ipairs(other_statements) do
+        other_statement.maybe_multiply_defined = true
+      end
+    end
+  end
+end
+
 -- Remove auxiliary intermediate results to free up memory for the following processing steps.
 local function cleanup(states, file_number, _)
   -- Remove group-wide intermediate results.
@@ -2372,7 +2410,8 @@ local substeps = {
   collect_statements,
   analyze_group_wide_statements,
   report_issues,
-  determine_used_function_definitions,
+  determine_maybe_multiply_defined_function_definitions,
+  determine_maybe_used_function_definitions,
   cleanup,
 }
 

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -1447,7 +1447,7 @@ local function analyze_group_wide_statements(states, _, options)
       used_message_nums_text_arguments = {},
 
       -- Index file-local statements.
-      function_call_and_variant_definition_list = {},
+      function_call_variant_definition_and_indirect_definition_list = {},
       non_redefined_function_and_variant_definition_list = {},
     }
     for _, segment in ipairs(results.segments or {}) do
@@ -1719,7 +1719,7 @@ local function analyze_group_wide_statements(states, _, options)
             table.insert(results.statement_analysis.non_redefined_function_and_variant_definition_list, statement)
           end
           if statement.base_csname.type == TEXT then
-            table.insert(results.statement_analysis.function_call_and_variant_definition_list, statement)
+            table.insert(results.statement_analysis.function_call_variant_definition_and_indirect_definition_list, statement)
           end
         -- Process a function definition.
         elseif statement.type == FUNCTION_DEFINITION then
@@ -1778,6 +1778,9 @@ local function analyze_group_wide_statements(states, _, options)
               table.insert(non_redefined_index[statement.defined_csname.payload], statement)
               table.insert(results.statement_analysis.non_redefined_function_and_variant_definition_list, statement)
             end
+          end
+          if statement.subtype == FUNCTION_DEFINITION_INDIRECT and statement.base_csname.type == TEXT then
+            table.insert(results.statement_analysis.function_call_variant_definition_and_indirect_definition_list, statement)
           end
         -- Process a function undefinition.
         elseif statement.type == FUNCTION_UNDEFINITION then
@@ -2126,7 +2129,7 @@ local function report_issues(states, file_number, options)
       end
       -- Index the function call.
       if statement.used_csname.type == TEXT then
-        table.insert(results.statement_analysis.function_call_and_variant_definition_list, statement)
+        table.insert(results.statement_analysis.function_call_variant_definition_and_indirect_definition_list, statement)
       end
     end
   end
@@ -2318,12 +2321,17 @@ local function determine_maybe_used_function_definitions(states, file_number, _)
   -- For each function call, first collect all relevant (potentially but not necessarily reaching) definitions to a temporary list.
   local function_and_variant_definitions_and_undefinition_list = {}
   local seen_used_csnames = {}
-  for _, statement in ipairs(results.statement_analysis.function_call_and_variant_definition_list) do
+  for _, statement in ipairs(results.statement_analysis.function_call_variant_definition_and_indirect_definition_list) do
     local used_csname
     if statement.type == FUNCTION_CALL then
       used_csname = statement.used_csname
     elseif statement.type == FUNCTION_VARIANT_DEFINITION then
       used_csname = statement.base_csname
+    elseif statement.type == FUNCTION_DEFINITION then
+      assert(statement.subtype == FUNCTION_DEFINITION_INDIRECT)
+      used_csname = statement.base_csname
+    else
+      error('Unexpected statement type "' .. statement.type .. '" and subtype "' .. statement.subtype .. '"')
     end
     assert(used_csname ~= nil)
     assert(used_csname.type == TEXT)

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -2383,9 +2383,7 @@ local function determine_maybe_multiply_defined_function_definitions(states, fil
     local defined_csname = statement.defined_csname.payload
     local other_statements = states.results.statement_analysis.non_redefined_function_definition_index[defined_csname]
     if #other_statements > 1 then
-      for _, other_statement in ipairs(other_statements) do
-        other_statement.maybe_multiply_defined = true
-      end
+      statement.maybe_multiply_defined = true
     end
   end
 end

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -2422,12 +2422,10 @@ local function determine_maybe_multiply_defined_function_definitions(states, fil
   end
 end
 
--- Remove auxiliary intermediate results to free up memory for the following processing steps.
+-- Remove auxiliary intermediate results to free up memory.
 local function cleanup(states, file_number, _)
   -- Remove group-wide intermediate results.
-  if states.results.statement_analysis ~= nil then
-    states.results.statement_analysis = nil
-  end
+  states.results.statement_analysis = nil
 
   -- Remove file-local intermediate results.
   local state = states[file_number]

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -874,6 +874,7 @@ local function collect_statements(states, file_number, options)
                   map_forward = map_forward,
                 },
               }
+              nested_segment.min_reaching_nesting_depth = nested_segment.nesting_depth
               table.insert(results.segments, nested_segment)
               replacement_text_argument.segment_number = #results.segments
               nested_segment.calls = get_calls(results, part_number, nested_segment, issues, content)

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -762,7 +762,7 @@ local function collect_statements(states, file_number, options)
               defined_csname = defined_csname,
               is_private = is_function_private(base_csname),
               is_conditional = is_conditional,
-              maybe_called = false,
+              maybe_used = false,
             }
             table.insert(statements, statement)
           end
@@ -924,7 +924,7 @@ local function collect_statements(states, file_number, options)
                 defined_csname = effectively_defined_csname,
                 defined_csname_argument = defined_csname_argument,
                 definition_token_range = definition_token_range,
-                maybe_called = false,
+                maybe_used = false,
                 maybe_multiply_defined = false,
                 -- The following attributes are specific to the subtype.
                 is_conditional = is_conditional,
@@ -1001,7 +1001,7 @@ local function collect_statements(states, file_number, options)
                 defined_csname = effectively_defined_csname,
                 defined_csname_argument = defined_csname_argument,
                 definition_token_range = token_range,
-                maybe_called = false,
+                maybe_used = false,
                 maybe_multiply_defined = false,
                 -- The following attributes are specific to the subtype.
                 base_csname = effective_base_csname,
@@ -1037,7 +1037,7 @@ local function collect_statements(states, file_number, options)
             -- The following attributes are specific to the type.
             undefined_csname = undefined_csname,
             undefined_csname_argument = undefined_csname_argument,
-            maybe_called = false,
+            maybe_used = false,
           }
           table.insert(statements, statement)
           goto continue

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -2392,7 +2392,7 @@ local function determine_maybe_multiply_defined_function_definitions(states, fil
     assert(defined_or_undefined_csname ~= nil)
     assert(defined_or_undefined_csname.type == TEXT)
     local other_statements = states.results.statement_analysis.non_redefined_function_definition_index[defined_or_undefined_csname.payload]
-    if #other_statements > 1 then
+    if other_statements ~= nil and #other_statements > 1 then
       statement.maybe_multiply_defined = true
     end
   end

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -1777,6 +1777,9 @@ local function analyze_group_wide_statements(states, _, options)
               states.results.statement_analysis.function_definition_index[statement.undefined_csname.payload] = {}
             end
             table.insert(states.results.statement_analysis.function_definition_index[statement.undefined_csname.payload], statement)
+            if not statement.maybe_redefined then
+              table.insert(results.statement_analysis.non_redefined_function_definition_list, statement)
+            end
           end
         -- Process a variable declaration.
         elseif statement.type == VARIABLE_DECLARATION then
@@ -2360,7 +2363,7 @@ local function determine_maybe_used_function_definitions(states, file_number, _)
         ::next_other_statement::
       end
     else
-      error('Unexpected statement type and "' .. statement.type .. '" and subtype "' .. statement.subtype .. '"')
+      error('Unexpected statement type "' .. statement.type .. '" and subtype "' .. statement.subtype .. '"')
     end
     ::next_statement::
     statement_number = statement_number + 1
@@ -2378,10 +2381,17 @@ local function determine_maybe_multiply_defined_function_definitions(states, fil
 
   -- For each non-redefining function definition, check if other non-redefining definitions exist.
   for _, statement in ipairs(results.statement_analysis.non_redefined_function_definition_list) do
-    assert(statement.type == FUNCTION_DEFINITION)
-    assert(statement.defined_csname.type == TEXT)
-    local defined_csname = statement.defined_csname.payload
-    local other_statements = states.results.statement_analysis.non_redefined_function_definition_index[defined_csname]
+    local defined_or_undefined_csname
+    if statement.type == FUNCTION_DEFINITION then
+      defined_or_undefined_csname = statement.defined_csname
+    elseif statement.type == FUNCTION_UNDEFINITION then
+      defined_or_undefined_csname = statement.undefined_csname
+    else
+      error('Unexpected statement type "' .. statement.type .. '"')
+    end
+    assert(defined_or_undefined_csname ~= nil)
+    assert(defined_or_undefined_csname.type == TEXT)
+    local other_statements = states.results.statement_analysis.non_redefined_function_definition_index[defined_or_undefined_csname.payload]
     if #other_statements > 1 then
       statement.maybe_multiply_defined = true
     end

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -763,6 +763,7 @@ local function collect_statements(states, file_number, options)
               is_private = is_function_private(base_csname),
               is_conditional = is_conditional,
               maybe_used = false,
+              maybe_multiply_defined = false,
             }
             table.insert(statements, statement)
           end
@@ -1406,7 +1407,7 @@ local function analyze_group_wide_statements(states, _, options)
 
     -- Index group-wide statements.
     function_definition_index = {},
-    non_redefined_function_definition_index = {},
+    non_redefined_function_and_variant_definition_and_undefinition_index = {},
   }
 
   -- Collect all segments of top-level and nested tokens, calls, and statements from all files within the group.
@@ -1446,8 +1447,8 @@ local function analyze_group_wide_statements(states, _, options)
       used_message_nums_text_arguments = {},
 
       -- Index file-local statements.
-      function_call_list = {},
-      non_redefined_function_definition_list = {},
+      function_call_and_variant_definition_list = {},
+      non_redefined_function_and_variant_definition_list = {},
     }
     for _, segment in ipairs(results.segments or {}) do
       assert(file_number == segment.location.file_number)
@@ -1709,6 +1710,16 @@ local function analyze_group_wide_statements(states, _, options)
               states.results.statement_analysis.function_definition_index[statement.defined_csname.payload] = {}
             end
             table.insert(states.results.statement_analysis.function_definition_index[statement.defined_csname.payload], statement)
+            local non_redefined_index
+              = states.results.statement_analysis.non_redefined_function_and_variant_definition_and_undefinition_index
+            if non_redefined_index[statement.defined_csname.payload] == nil then
+              non_redefined_index[statement.defined_csname.payload] = {}
+            end
+            table.insert(non_redefined_index[statement.defined_csname.payload], statement)
+            table.insert(results.statement_analysis.non_redefined_function_and_variant_definition_list, statement)
+          end
+          if statement.base_csname.type == TEXT then
+            table.insert(results.statement_analysis.function_call_and_variant_definition_list, statement)
           end
         -- Process a function definition.
         elseif statement.type == FUNCTION_DEFINITION then
@@ -1759,14 +1770,13 @@ local function analyze_group_wide_statements(states, _, options)
             end
             table.insert(states.results.statement_analysis.function_definition_index[statement.defined_csname.payload], statement)
             if not statement.maybe_redefined then
-              if states.results.statement_analysis.non_redefined_function_definition_index[statement.defined_csname.payload] == nil then
-                states.results.statement_analysis.non_redefined_function_definition_index[statement.defined_csname.payload] = {}
+              local non_redefined_index
+                = states.results.statement_analysis.non_redefined_function_and_variant_definition_and_undefinition_index
+              if non_redefined_index[statement.defined_csname.payload] == nil then
+                non_redefined_index[statement.defined_csname.payload] = {}
               end
-              table.insert(
-                states.results.statement_analysis.non_redefined_function_definition_index[statement.defined_csname.payload],
-                statement
-              )
-              table.insert(results.statement_analysis.non_redefined_function_definition_list, statement)
+              table.insert(non_redefined_index[statement.defined_csname.payload], statement)
+              table.insert(results.statement_analysis.non_redefined_function_and_variant_definition_list, statement)
             end
           end
         -- Process a function undefinition.
@@ -1778,7 +1788,7 @@ local function analyze_group_wide_statements(states, _, options)
             end
             table.insert(states.results.statement_analysis.function_definition_index[statement.undefined_csname.payload], statement)
             if not statement.maybe_redefined then
-              table.insert(results.statement_analysis.non_redefined_function_definition_list, statement)
+              table.insert(results.statement_analysis.non_redefined_function_and_variant_definition_list, statement)
             end
           end
         -- Process a variable declaration.
@@ -2116,7 +2126,7 @@ local function report_issues(states, file_number, options)
       end
       -- Index the function call.
       if statement.used_csname.type == TEXT then
-        table.insert(results.statement_analysis.function_call_list, statement)
+        table.insert(results.statement_analysis.function_call_and_variant_definition_list, statement)
       end
     end
   end
@@ -2308,16 +2318,21 @@ local function determine_maybe_used_function_definitions(states, file_number, _)
   -- For each function call, first collect all relevant (potentially but not necessarily reaching) definitions to a temporary list.
   local function_and_variant_definitions_and_undefinition_list = {}
   local seen_used_csnames = {}
-  for _, statement in ipairs(results.statement_analysis.function_call_list) do
-    assert(statement.type == FUNCTION_CALL)
-    assert(statement.used_csname.type == TEXT)
-    local used_csname = statement.used_csname.payload
+  for _, statement in ipairs(results.statement_analysis.function_call_and_variant_definition_list) do
+    local used_csname
+    if statement.type == FUNCTION_CALL then
+      used_csname = statement.used_csname
+    elseif statement.type == FUNCTION_VARIANT_DEFINITION then
+      used_csname = statement.base_csname
+    end
+    assert(used_csname ~= nil)
+    assert(used_csname.type == TEXT)
     -- Do not repeatedly check the same calls.
-    if seen_used_csnames[used_csname] ~= nil then
+    if seen_used_csnames[used_csname.payload] ~= nil then
       goto next_statement
     end
-    seen_used_csnames[used_csname] = true
-    local other_statements = states.results.statement_analysis.function_definition_index[used_csname]
+    seen_used_csnames[used_csname.payload] = true
+    local other_statements = states.results.statement_analysis.function_definition_index[used_csname.payload]
     for _, other_statement in ipairs(other_statements or {}) do
       -- Do not repeatedly check the same definitions.
       if other_statement.maybe_used then
@@ -2380,9 +2395,9 @@ local function determine_maybe_multiply_defined_function_definitions(states, fil
   assert(results.statement_analysis ~= nil)
 
   -- For each non-redefining function definition, check if other non-redefining definitions exist.
-  for _, statement in ipairs(results.statement_analysis.non_redefined_function_definition_list) do
+  for _, statement in ipairs(results.statement_analysis.non_redefined_function_and_variant_definition_list) do
     local defined_or_undefined_csname
-    if statement.type == FUNCTION_DEFINITION then
+    if statement.type == FUNCTION_DEFINITION or statement.type == FUNCTION_VARIANT_DEFINITION then
       defined_or_undefined_csname = statement.defined_csname
     elseif statement.type == FUNCTION_UNDEFINITION then
       defined_or_undefined_csname = statement.undefined_csname
@@ -2391,7 +2406,8 @@ local function determine_maybe_multiply_defined_function_definitions(states, fil
     end
     assert(defined_or_undefined_csname ~= nil)
     assert(defined_or_undefined_csname.type == TEXT)
-    local other_statements = states.results.statement_analysis.non_redefined_function_definition_index[defined_or_undefined_csname.payload]
+    local non_redefined_index = states.results.statement_analysis.non_redefined_function_and_variant_definition_and_undefinition_index
+    local other_statements = non_redefined_index[defined_or_undefined_csname.payload]
     if other_statements ~= nil and #other_statements > 1 then
       statement.maybe_multiply_defined = true
     end

--- a/explcheck/src/explcheck-syntactic-analysis.lua
+++ b/explcheck/src/explcheck-syntactic-analysis.lua
@@ -623,6 +623,7 @@ local function get_calls(results, part_number, segment, issues, content)
                       map_forward = map_forward,
                     },
                   }
+                  nested_segment.min_reaching_nesting_depth = nested_segment.nesting_depth
                   table.insert(results.segments, nested_segment)
                   argument.segment_number = #results.segments
                   nested_segment.calls = get_calls(results, part_number, nested_segment, issues, content)
@@ -729,6 +730,7 @@ local function analyze_and_report_issues(states, file_number, options)  -- luach
         part_number = part_number,
       },
       nesting_depth = 1,
+      min_reaching_nesting_depth = 1,
       transformed_tokens = {
         tokens = part_tokens,
         token_range = new_range(1, #part_tokens, INCLUSIVE, #part_tokens),
@@ -736,6 +738,7 @@ local function analyze_and_report_issues(states, file_number, options)  -- luach
         map_forward = identity,
       },
     }
+    assert(segment.min_reaching_nesting_depth == segment.nesting_depth)
     table.insert(results.segments, segment)
     table.insert(results.parts, segment)
     segment.calls = get_calls(results, part_number, segment, issues, content)

--- a/explcheck/testfiles/TL2025-issues/e405.txt
+++ b/explcheck/testfiles/TL2025-issues/e405.txt
@@ -1,2 +1,3 @@
+/usr/local/texlive/2025/texmf-dist/tex/latex/tabular2/tabular2.sty
 /usr/local/texlive/2025/texmf-dist/tex/latex/tikzquads/tikzquads.sty
 /usr/local/texlive/2025/texmf-dist/tex/lualatex/lua-unicode-math/lua-unicode-math.sty

--- a/explcheck/testfiles/TL2025-issues/w507.txt
+++ b/explcheck/testfiles/TL2025-issues/w507.txt
@@ -1,0 +1,7 @@
+/usr/local/texlive/2025/texmf-dist/tex/latex/antanilipsum/antanilipsum.sty
+/usr/local/texlive/2025/texmf-dist/tex/latex/bookmark/bookmark.sty
+/usr/local/texlive/2025/texmf-dist/tex/latex/dataref/dataref.sty
+/usr/local/texlive/2025/texmf-dist/tex/latex/econlipsum/econlipsum.sty
+/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/nameref.sty
+/usr/local/texlive/2025/texmf-dist/tex/latex/linguistix/linguistix-greek.sty
+/usr/local/texlive/2025/texmf-dist/tex/latex/powerdot/powerdot.cls

--- a/explcheck/testfiles/e500-01.lua
+++ b/explcheck/testfiles/e500-01.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e500-01.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{4, 6}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e500")
+  assert(err[2] == "multiply defined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e500-01.tex
+++ b/explcheck/testfiles/e500-01.tex
@@ -1,0 +1,6 @@
+\cs_new:Nn
+  \module_foo:
+  { bar }
+\cs_new:Nn  % error on this line
+  \module_foo:
+  { bar }

--- a/explcheck/testfiles/e500-02.tex
+++ b/explcheck/testfiles/e500-02.tex
@@ -1,0 +1,8 @@
+\cs_new:Nn
+  \module_foo:
+  { bar }
+\cs_undefine:N
+  \module_foo:
+\cs_new:Nn
+  \module_foo:
+  { bar }

--- a/explcheck/testfiles/e500-03.tex
+++ b/explcheck/testfiles/e500-03.tex
@@ -1,0 +1,6 @@
+\cs_new:Nn
+  \module_foo:
+  { bar }
+\cs_gset:Nn
+  \module_foo:
+  { bar }

--- a/explcheck/testfiles/e500-04.lua
+++ b/explcheck/testfiles/e500-04.lua
@@ -10,10 +10,10 @@ local options = {
 local state = table.unpack(utils.process_files({filename}, options))
 local issues, results = state.issues, state.results
 
-assert(#issues.errors == 1)
+assert(#issues.errors == 4)
 assert(#issues.warnings == 0)
 
-local expected_line_numbers = {{5, 8}}
+local expected_line_numbers = {{5, 8}, {5, 8}, {5, 8}, {5, 8}}
 for index, err in ipairs(sort_issues(issues.errors)) do
   assert(err[1] == "e500")
   assert(err[2] == "multiply defined function")

--- a/explcheck/testfiles/e500-04.lua
+++ b/explcheck/testfiles/e500-04.lua
@@ -5,6 +5,7 @@ local filename = "e500-04.tex"
 local options = {
   expl3_detection_strategy = "always",
   stop_after = "flow analysis",
+  stop_early_when_confused = false,
 }
 local state = table.unpack(utils.process_files({filename}, options))
 local issues, results = state.issues, state.results

--- a/explcheck/testfiles/e500-04.lua
+++ b/explcheck/testfiles/e500-04.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e500-04.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{5, 8}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e500")
+  assert(err[2] == "multiply defined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e500-04.tex
+++ b/explcheck/testfiles/e500-04.tex
@@ -1,0 +1,8 @@
+\prg_new_conditional:Nnn
+  \module_foo:
+  { p, T, F, TF }
+  { \prg_return_true: }
+\prg_new_conditional:Nnn  % error on this line
+  \module_foo:
+  { p, T, F, TF }
+  { \prg_return_true: }

--- a/explcheck/testfiles/e500-05.tex
+++ b/explcheck/testfiles/e500-05.tex
@@ -1,0 +1,16 @@
+\prg_new_conditional:Nnn
+  \module_foo:
+  { p, T, F, TF }
+  { \prg_return_true: }
+\cs_undefine:N
+  \module_foo_p:
+\cs_undefine:N
+  \module_foo:T
+\cs_undefine:N
+  \module_foo:F
+\cs_undefine:N
+  \module_foo:TF
+\prg_new_conditional:Nnn
+  \module_foo:
+  { p, T, F, TF }
+  { \prg_return_true: }

--- a/explcheck/testfiles/e500-06.tex
+++ b/explcheck/testfiles/e500-06.tex
@@ -1,0 +1,8 @@
+\prg_new_conditional:Nnn
+  \module_foo:
+  { p, T, F, TF }
+  { \prg_return_true: }
+\prg_gset_conditional:Nnn
+  \module_foo:
+  { p, T, F, TF }
+  { \prg_return_true: }

--- a/explcheck/testfiles/e504-01.tex
+++ b/explcheck/testfiles/e504-01.tex
@@ -1,0 +1,6 @@
+\cs_new:Nn
+  \module_foo:n
+  { bar }
+\cs_generate_variant:Nn
+  \module_foo:n
+  { V }

--- a/explcheck/testfiles/e504-02.lua
+++ b/explcheck/testfiles/e504-02.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e504-02.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{1, 3}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e504")
+  assert(err[2] == "function variant for an undefined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e504-02.tex
+++ b/explcheck/testfiles/e504-02.tex
@@ -1,0 +1,6 @@
+\cs_generate_variant:Nn  % error on this line
+  \module_foo:n
+  { V }
+\cs_new:Nn
+  \module_foo:n
+  { bar }

--- a/explcheck/testfiles/e504-03.lua
+++ b/explcheck/testfiles/e504-03.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e504-03.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{6, 8}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e504")
+  assert(err[2] == "function variant for an undefined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e504-03.tex
+++ b/explcheck/testfiles/e504-03.tex
@@ -1,0 +1,8 @@
+\cs_new:Nn
+  \module_foo:n
+  { bar }
+\cs_undefine:N
+  \module_foo:n
+\cs_generate_variant:Nn  % error on this line
+  \module_foo:n
+  { V }

--- a/explcheck/testfiles/e504-04.tex
+++ b/explcheck/testfiles/e504-04.tex
@@ -1,0 +1,8 @@
+\prg_new_conditional:Nnn
+  \module_foo:n
+  { p, T, F, TF }
+  { \prg_return_true: }
+\prg_generate_conditional_variant:Nnn
+  \module_foo:n
+  { V }
+  { TF }

--- a/explcheck/testfiles/e504-05.lua
+++ b/explcheck/testfiles/e504-05.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e504-05.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{1, 4}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e504")
+  assert(err[2] == "function variant for an undefined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e504-05.tex
+++ b/explcheck/testfiles/e504-05.tex
@@ -1,0 +1,8 @@
+\prg_generate_conditional_variant:Nnn  % error on this line
+  \module_foo:n
+  { V }
+  { TF }
+\prg_new_conditional:Nnn
+  \module_foo:n
+  { p, T, F, TF }
+  { \prg_return_true: }

--- a/explcheck/testfiles/e504-06.lua
+++ b/explcheck/testfiles/e504-06.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e504-06.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{7, 10}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e504")
+  assert(err[2] == "function variant for an undefined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e504-06.tex
+++ b/explcheck/testfiles/e504-06.tex
@@ -1,0 +1,10 @@
+\prg_new_conditional:Nnn
+  \module_foo:n
+  { p, T, F, TF }
+  { \prg_return_true: }
+\cs_undefine:N
+  \module_foo:nTF
+\prg_generate_conditional_variant:Nnn  % error on this line
+  \module_foo:n
+  { V }
+  { TF }

--- a/explcheck/testfiles/e506-01.lua
+++ b/explcheck/testfiles/e506-01.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e506-01.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{4, 6}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e506")
+  assert(err[2] == "indirect function definition from an undefined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e506-01.tex
+++ b/explcheck/testfiles/e506-01.tex
@@ -1,0 +1,9 @@
+\cs_new:Nn
+  \module_foo:n
+  { bar }
+\cs_new_eq:NN  % error on this line
+  \module_baz:n
+  \module_bar:n
+\cs_new_eq:NN
+  \module_bar:n
+  \module_foo:n

--- a/explcheck/testfiles/e506-02.lua
+++ b/explcheck/testfiles/e506-02.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e506-02.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{9, 11}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e506")
+  assert(err[2] == "indirect function definition from an undefined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e506-02.tex
+++ b/explcheck/testfiles/e506-02.tex
@@ -1,0 +1,11 @@
+\cs_new:Nn
+  \module_foo:n
+  { bar }
+\cs_new_eq:NN
+  \module_bar:n
+  \module_foo:n
+\cs_undefine:N
+  \module_bar:n
+\cs_new_eq:NN  % error on this line
+  \module_baz:n
+  \module_bar:n

--- a/explcheck/testfiles/e506-03.lua
+++ b/explcheck/testfiles/e506-03.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e506-03.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{5, 7}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e506")
+  assert(err[2] == "indirect function definition from an undefined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e506-03.tex
+++ b/explcheck/testfiles/e506-03.tex
@@ -1,0 +1,10 @@
+\prg_new_conditional:Nnn
+  \module_foo:n
+  { p, T, F, TF }
+  { \prg_return_true: }
+\cs_new_eq:NN  % error on this line
+  \module_baz:nTF
+  \module_bar:nTF
+\cs_new_eq:NN
+  \module_bar:nTF
+  \module_foo:nTF

--- a/explcheck/testfiles/e506-04.lua
+++ b/explcheck/testfiles/e506-04.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "e506-04.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 1)
+assert(#issues.warnings == 0)
+
+local expected_line_numbers = {{10, 12}}
+for index, err in ipairs(sort_issues(issues.errors)) do
+  assert(err[1] == "e506")
+  assert(err[2] == "indirect function definition from an undefined function")
+  local byte_range = err[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/e506-04.tex
+++ b/explcheck/testfiles/e506-04.tex
@@ -1,0 +1,12 @@
+\prg_new_conditional:Nnn
+  \module_foo:n
+  { p, T, F, TF }
+  { \prg_return_true: }
+\cs_new_eq:NN
+  \module_bar:nTF
+  \module_foo:nTF
+\cs_undefine:N
+  \module_bar:nTF
+\cs_new_eq:NN  % error on this line
+  \module_baz:nTF
+  \module_bar:nTF

--- a/explcheck/testfiles/w501-01.lua
+++ b/explcheck/testfiles/w501-01.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "w501-01.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 0)
+assert(#issues.warnings == 1)
+
+local expected_line_numbers = {{7, 9}}
+for index, warning in ipairs(sort_issues(issues.warnings)) do
+  assert(warning[1] == "w501")
+  assert(warning[2] == "multiply defined function variant")
+  local byte_range = warning[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/w501-01.tex
+++ b/explcheck/testfiles/w501-01.tex
@@ -1,0 +1,9 @@
+\cs_new:Nn
+  \module_foo:n
+  { bar~#1 }
+\cs_generate_variant:Nn
+  \module_foo:n
+  { V }
+\cs_generate_variant:Nn  % warning on this line
+  \module_foo:n
+  { o, V }

--- a/explcheck/testfiles/w501-01.tex
+++ b/explcheck/testfiles/w501-01.tex
@@ -1,6 +1,6 @@
 \cs_new:Nn
   \module_foo:n
-  { bar~#1 }
+  { bar }
 \cs_generate_variant:Nn
   \module_foo:n
   { V }

--- a/explcheck/testfiles/w501-02.tex
+++ b/explcheck/testfiles/w501-02.tex
@@ -1,0 +1,11 @@
+\cs_new:Nn
+  \module_foo:n
+  { bar~#1 }
+\cs_generate_variant:Nn
+  \module_foo:n
+  { V }
+\cs_undefine:N
+  \module_foo:V
+\cs_generate_variant:Nn
+  \module_foo:n
+  { o, V }

--- a/explcheck/testfiles/w501-02.tex
+++ b/explcheck/testfiles/w501-02.tex
@@ -1,6 +1,6 @@
 \cs_new:Nn
   \module_foo:n
-  { bar~#1 }
+  { bar }
 \cs_generate_variant:Nn
   \module_foo:n
   { V }

--- a/explcheck/testfiles/w501-03.lua
+++ b/explcheck/testfiles/w501-03.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "w501-03.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 0)
+assert(#issues.warnings == 1)
+
+local expected_line_numbers = {{9, 12}}
+for index, warning in ipairs(sort_issues(issues.warnings)) do
+  assert(warning[1] == "w501")
+  assert(warning[2] == "multiply defined function variant")
+  local byte_range = warning[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/w501-03.tex
+++ b/explcheck/testfiles/w501-03.tex
@@ -1,0 +1,12 @@
+\prg_new_conditional:Nnn
+  \module_foo:n
+  { p, T, F, TF }
+  { \prg_return_true: }
+\prg_generate_conditional_variant:Nnn
+  \module_foo:n
+  { V }
+  { TF }
+\prg_generate_conditional_variant:Nnn  % warning on this line
+  \module_foo:n
+  { o, V }
+  { TF }

--- a/explcheck/testfiles/w501-04.tex
+++ b/explcheck/testfiles/w501-04.tex
@@ -1,0 +1,14 @@
+\prg_new_conditional:Nnn
+  \module_foo:n
+  { p, T, F, TF }
+  { \prg_return_true: }
+\prg_generate_conditional_variant:Nnn
+  \module_foo:n
+  { V }
+  { TF }
+\cs_undefine:N
+  \module_foo:VTF
+\prg_generate_conditional_variant:Nnn
+  \module_foo:n
+  { o, V }
+  { TF }

--- a/explcheck/testfiles/w507-01.lua
+++ b/explcheck/testfiles/w507-01.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "w507-01.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 0)
+assert(#issues.warnings == 1)
+
+local expected_line_numbers = {{1, 3}}
+for index, warning in ipairs(sort_issues(issues.warnings)) do
+  assert(warning[1] == "w507")
+  assert(warning[2] == "setting a function before definition")
+  local byte_range = warning[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/w507-01.tex
+++ b/explcheck/testfiles/w507-01.tex
@@ -1,0 +1,6 @@
+\cs_gset:Nn  % warning on this line
+  \module_foo:
+  { foo }
+\cs_new:Nn
+  \module_foo:
+  { bar }

--- a/explcheck/testfiles/w507-02.lua
+++ b/explcheck/testfiles/w507-02.lua
@@ -1,0 +1,24 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "w507-02.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 0)
+assert(#issues.warnings == 1)
+
+local expected_line_numbers = {{6, 8}}
+for index, warning in ipairs(sort_issues(issues.warnings)) do
+  assert(warning[1] == "w507")
+  assert(warning[2] == "setting a function before definition")
+  local byte_range = warning[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+end

--- a/explcheck/testfiles/w507-02.tex
+++ b/explcheck/testfiles/w507-02.tex
@@ -1,0 +1,8 @@
+\cs_new:Nn
+  \module_foo:
+  { bar }
+\cs_undefine:N
+  \module_foo:
+\cs_gset:Nn  % warning on this line
+  \module_foo:
+  { foo }


### PR DESCRIPTION
This PR continues #176 based on the tasks outlined there and [the recent blog post](https://witiko.github.io/Expl3-Linter-11.5/):

- [ ] Report issues from _Section 5.1 (Functions and conditional functions)_ from the document titled [_Warnings and errors for the expl3 analysis tool_](https://github.com/witiko/expltools/releases/download/latest/warnings-and-errors.pdf):
    - [x] Report issues that we can report by just modifying existing analyses:
        - [x] Report issues _E500 (Multiply defined function)_ and _W501 (Multiply defined function variant)_.
        - [x] Report issues _E504 (Function variant for an undefined function)_, _E506 (Indirect function definition from an undefined function)_, and _W507 (Setting a function before definition)_.
        - [x] Move all issue reporting to `report_issues()`.
        - [ ] ~~Recognize `\prg_return_true:` and `\prg_return_false:` as known statements, use them to better determine the control flow for conditional function calls in the flow analysis, and use the increase in code understanding to remove `stop_early_when_confused = true` from the test file `e500-04.lua`.~~ This task is already tracked in [\#190](https://github.com/Witiko/expltools/issues/190).
        - [x] Report issues E505 and W507 for all code reachable from the top level, not just at top level.
            - This will likely require a separate analysis after reaching definitions that will build a graph over segments and, for each segment, record in the property `min_reaching_nesting_depth` the minimum nesting depth from which this segment is reachable, starting with its own nesting depth. A statement given by `(chunk, statement_number)` is then likely reachable from the top level when `chunk.segment.min_reaching_nesting_depth == 1`.
            - In some cases, only the segment may be reachable but not a specific statement from that segment. If this produces many false positive detections, we can make the analysis more accurate by recording the minimum reaching nesting depth for every statement at the cost of a more expensive analysis.
    - [ ] Report issues that we can report by adding new data-flow analyses:
        - [ ] Report issues _W502 (Unused private function)_ and _W503 (Unused private function variant)_.
    - [ ] Report issues that we can report by updating the semantic analysis and adding new data-flow analyses:
        - [ ] Report issues _E508 (Unexpandable or restricted-expandable boolean expression)_, _E509 (Expanding an unexpandable function)_, _E510 (Fully-expanding a restricted-expandable function)_, and _W512 (Defined an unexpandable function as unprotected)_.
        - [ ] Report issue _W511 (Defined an expandable function as protected)_.
        - [ ] Report issues _E513 (Conditional function with no return value)_ and _E514 (Conditional function with no return value)_.
        - [ ] Report issue _E515 (Comparison code with no return value)_.
        - [ ] Report issue _E516 (Paragraph token in the parameter of a "nopar" function)_.
- [x] Update the file `CHANGES.md`.