### PR TITLE
Report issues W502 (Unused private function) and W503 (Unused private function variant)

### DIFF
--- a/.explcheckrc
+++ b/.explcheckrc
@@ -545,13 +545,13 @@ imported_prefixes = ["hooks"]
 expl3_detection_strategy = "never"
 
 [package.antanilipsum]
-ignored_issues = ["e505"]
+ignored_issues = ["e505", "w502"]
 
 [package.econlipsum]
-ignored_issues = ["e505"]
+ignored_issues = ["e505", "w502"]
 
 [package.kantlipsum]
-ignored_issues = ["e505"]
+ignored_issues = ["e505", "w502"]
 
 [package.novel]
 ignored_issues = ["e506"]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,18 @@
 
 ### explcheck v0.20.0
 
+#### New features
+
+This version of explcheck has implemented the following new features:
+
+- Add more support for flow analysis. (#188)
+
+  This adds support for the following issues from Section 5.1 of the document
+  titled [_Warnings and errors for the expl3 analysis tool_][warnings-and-errors]:
+
+  1. W502 (Unused private function)
+  2. W503 (Unused private function variant)
+
 #### Continuous integration
 
 This version of explcheck has made the following changes to our continuous

--- a/explcheck/doc/w502.tex
+++ b/explcheck/doc/w502.tex
@@ -1,6 +1,1 @@
-\cs_new:Nn  % warning on this line
-  \__module_foo:
-  { bar }
-\cs_new:Nn
-  \__module_baz:
-  { \__module_foo: }
+../testfiles/w502.tex

--- a/explcheck/doc/w503.tex
+++ b/explcheck/doc/w503.tex
@@ -1,17 +1,1 @@
-\cs_new:Nn
-  \__module_foo:n
-  { bar~#1 }
-\cs_new:Nn
-  \__module_baz:
-  {
-    \tl_set:Nn
-      \l_tmpa_tl
-      { baz }
-    \__module_foo:V
-      \l_tmpa_tl
-  }
-\cs_generate_variant:Nn  % warning on this line
-  \__module_foo:n
-  { V }
-\__module_foo:n
-  { baz }
+../testfiles/w503.tex

--- a/explcheck/doc/warnings-and-errors-05-flow-analysis.md
+++ b/explcheck/doc/warnings-and-errors-05-flow-analysis.md
@@ -21,34 +21,17 @@ A function or conditional function variant is defined multiple times.
  /w501-03.tex
  /w501-04.tex
 
-### Unused private function {.w}
+### Unused private function {.w label=w502}
 A private function or conditional function is defined but unused.
 
  /w502.tex
 
-<!--
-
-  We can't really report this issue from the `FUNCTION_CALL` edges alone
-  either, as is the case for the previous two issues. Furthermore, this
-  issue will require a live variable analysis, in addition to the reaching
-  definitions analysis. However, since liveness likely won't affect our ability
-  to determine reaching definitions, it might make sense to make it into a
-  separate substep.
-
--->
-
 This check is a stronger version of <#unused-private-function> and the issue should only be emitted if <#unused-private-function> has not previously been emitted for this function.
 
-### Unused private function variant {.w}
+### Unused private function variant {.w label=w503}
 A private function or conditional function variant is defined but unused.
 
  /w503.tex
-
-<!--
-
-  The same considerations apply as for the previous issue (W502).
-
--->
 
 This check is a stronger version of <#unused-private-function-variant> and the issue should only be emitted if <#unused-private-function-variant> has not previously been emitted for this function variant.
 

--- a/explcheck/src/explcheck-config.toml
+++ b/explcheck/src/explcheck-config.toml
@@ -26,7 +26,7 @@ min_simple_tokens_in_csname_pattern = 5
 porcelain = false
 stop_early_when_confused = true
 stop_after = "flow analysis"
-suppressed_issue_map = { w200 = ["s412", "s413", "s414"], e417 = ["e421"] }
+suppressed_issue_map = { w200 = ["s412", "s413", "s414"], e417 = ["e421"], w401 = ["w502"], w402 = ["w503"] }
 terminal_width = 80
 verbose = false
 warnings_are_errors = false

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1553,19 +1553,25 @@ local function report_issues(states, main_file_number, options)
                   (statement.type == FUNCTION_DEFINITION or statement.type == FUNCTION_VARIANT_DEFINITION) and
                   statement.is_private and
                   states.results.function_definition_in_edge_index[statement] == nil and
-                  statement.call_file_numbers ~= nil
+                  statement.call_segments ~= nil
                 ) then
               assert(statement.defined_csname.type == TEXT)
-              assert(#statement.call_file_numbers > 0)
-              local all_calls_reached_flow_analysis = true
-              for _, file_number in ipairs(statement.call_file_numbers) do
-                -- Do not check statements with calls in files that did not reach the flow analysis.
-                if states[file_number].results.stopped_early then
-                  all_calls_reached_flow_analysis = false
+              assert(#statement.call_segments > 0)
+              local all_calls_reached_flow_analysis_and_are_top_level_reachable = true
+              for _, call_segment in ipairs(statement.call_segments) do
+                if (
+                      -- Only consider function (variant) definition statements with calls reachable from top-level code.
+                      -- Otherwise, the calls are part of either dead code or library functions and we can't accurately determine
+                      -- their reaching definitions.
+                      call_segment.min_reaching_nesting_depth > 1 or
+                      -- Do not consider function (variant) definition statements with calls in files that did not reach the flow analysis.
+                      states[call_segment.location.file_number].results.stopped_early
+                    ) then
+                  all_calls_reached_flow_analysis_and_are_top_level_reachable = false
                   break
                 end
               end
-              if all_calls_reached_flow_analysis then
+              if all_calls_reached_flow_analysis_and_are_top_level_reachable then
                 local formatted_csname = format_csname(statement.defined_csname.payload)
                 local byte_range = get_byte_range()
 

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1118,21 +1118,11 @@ local function draw_group_wide_dynamic_edges(states, _, options)
 
     -- Update the current estimation of the function call edges.
     current_function_call_edges = {}
-    states.results.elided_function_call_edge_index = {}
-
+    states.results.function_definition_in_edge_index = {}
+    states.results.elided_function_call_out_edge_index = {}
     for _, function_call_chunk_and_statement_number in ipairs(function_call_list) do
       -- For each function call, first copy relevant reaching definitions to a temporary list.
       local function_call_chunk, function_call_statement_number = table.unpack(function_call_chunk_and_statement_number)
-
-      -- Record a function call statement as having the function call edge elided for some reason, so that we know that we
-      -- shouldn't report issues for that statement.
-      local function elide_function_call_edge()
-        if states.results.elided_function_call_edge_index[function_call_chunk] == nil then
-          states.results.elided_function_call_edge_index[function_call_chunk] = {}
-        end
-        states.results.elided_function_call_edge_index[function_call_chunk][function_call_statement_number] = true
-      end
-
       if states.results.reaching_definitions.indexes[function_call_chunk] == nil or
           states.results.reaching_definitions.indexes[function_call_chunk][function_call_statement_number] == nil then
         goto next_function_call
@@ -1179,7 +1169,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
               local l3prefixes_max_first_registered_date = get_option("l3prefixes_max_first_registered_date", options, state.pathname)
               local expl3_well_known_csname = parsers.expl3_well_known_csname(l3prefixes_max_first_registered_date, imported_prefixes)
               if lpeg.match(expl3_well_known_csname, base_csname) ~= nil then
-                elide_function_call_edge()
+                states.results.elided_function_call_out_edge_index[function_call_statement] = true
               end
             else
               for _, other_definition in ipairs(other_reaching_definition_index[base_csname] or {}) do
@@ -1227,9 +1217,12 @@ local function draw_group_wide_dynamic_edges(states, _, options)
         end
         local to_segment = results.segments[to_segment_number]
 
+        -- Index the definitions used in the function calls.
+        states.results.function_definition_in_edge_index[function_definition_statement] = true
+
         -- Elide calls to function definitions with empty replacement texts.
         if to_segment.chunks == nil or #to_segment.chunks == 0 then
-          elide_function_call_edge()
+          states.results.elided_function_call_out_edge_index[function_call_statement] = true
           goto next_function_definition
         end
 
@@ -1288,7 +1281,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
   until not any_edges_changed(previous_function_call_edges, current_function_call_edges)
 
   -- Record edges.
-  states.results.edge_indexes.function_call = {}
+  states.results.edge_indexes.function_call_out = {}
   for _, edge in ipairs(current_function_call_edges) do
     local results = states[edge.from.chunk.segment.location.file_number].results
     assert(results.edges ~= nil)
@@ -1296,7 +1289,7 @@ local function draw_group_wide_dynamic_edges(states, _, options)
       results.edges[DYNAMIC] = {}
     end
     table.insert(results.edges[DYNAMIC], edge)
-    index_edge(states, 'function_call', 'from', edge)
+    index_edge(states, 'function_call_out', 'from', edge)
   end
 end
 
@@ -1484,7 +1477,8 @@ local function report_issues(states, main_file_number, options)
             if (
                   statement.type == FUNCTION_DEFINITION and not statement.maybe_redefinition or
                   statement.type == FUNCTION_VARIANT_DEFINITION
-                ) and statement.defined_csname.type == TEXT then
+                ) then
+              assert(statement.defined_csname.type == TEXT)
               local defined_csname = statement.defined_csname.payload
               if any_reaching_definitions(
                     defined_csname,
@@ -1522,7 +1516,8 @@ local function report_issues(states, main_file_number, options)
             if (
                   statement.type == FUNCTION_VARIANT_DEFINITION or
                   statement.type == FUNCTION_DEFINITION and statement.subtype == FUNCTION_DEFINITION_INDIRECT
-                ) and statement.base_csname.type == TEXT then
+                ) then
+              assert(statement.base_csname.type == TEXT)
               local base_csname = statement.base_csname.payload
               if lpeg.match(expl3_well_known_csname, base_csname) == nil and
                   not any_reaching_definitions(base_csname) then
@@ -1543,16 +1538,46 @@ local function report_issues(states, main_file_number, options)
             end
 
             -- Report setting a function before definition.
-            if statement.type == FUNCTION_DEFINITION and statement.maybe_redefinition and statement.defined_csname.type == TEXT
-                -- Only consider function definitions reachable from top-level code. Otherwise, the definitions are part of either
-                -- dead code or library functions and we can't accurately determine their reaching definitions.
-                and segment.min_reaching_nesting_depth == 1 then
+            if statement.type == FUNCTION_DEFINITION and statement.maybe_redefinition then
+              assert(statement.defined_csname.type == TEXT)
               local defined_csname = statement.defined_csname.payload
               if lpeg.match(expl3_well_known_csname, defined_csname) == nil and
                   not any_reaching_definitions(defined_csname) then
                 local formatted_csname = format_csname(defined_csname)
                 local byte_range = get_byte_range()
                 issues:add("w507", "setting a function before definition", byte_range, formatted_csname)
+              end
+            end
+
+            if (
+                  (statement.type == FUNCTION_DEFINITION or statement.type == FUNCTION_VARIANT_DEFINITION) and
+                  statement.is_private and
+                  states.results.function_definition_in_edge_index[statement] == nil and
+                  statement.call_file_numbers ~= nil
+                ) then
+              assert(statement.defined_csname.type == TEXT)
+              assert(#statement.call_file_numbers > 0)
+              local all_calls_reached_flow_analysis = true
+              for _, file_number in ipairs(statement.call_file_numbers) do
+                -- Do not check statements with calls in files that did not reach the flow analysis.
+                if states[file_number].results.stopped_early then
+                  all_calls_reached_flow_analysis = false
+                  break
+                end
+              end
+              if all_calls_reached_flow_analysis then
+                local formatted_csname = format_csname(statement.defined_csname.payload)
+                local byte_range = get_byte_range()
+
+                -- Report unused private function definitions.
+                if statement.type == FUNCTION_DEFINITION then
+                  issues:add("w502", "unused private function", byte_range, formatted_csname)
+                -- Report unused private function variant definitions.
+                elseif statement.type == FUNCTION_VARIANT_DEFINITION then
+                  issues:add("w503", "unused private function variant", byte_range, formatted_csname)
+                else
+                  error('Unexpected statement type "' .. statement.type .. '"')
+                end
               end
             end
 
@@ -1588,23 +1613,22 @@ local function report_issues(states, main_file_number, options)
           assert(#statement.definition_file_numbers > 0)
           local all_definitions_reached_flow_analysis = true
           for _, file_number in ipairs(statement.definition_file_numbers) do
-            -- Do not check statements originating from files that did not reach the flow analysis.
+            -- Do not check statements with definitions in files that did not reach the flow analysis.
             if states[file_number].results.stopped_early then
               all_definitions_reached_flow_analysis = false
               break
             end
           end
           if all_definitions_reached_flow_analysis then
-            if states.results.edge_indexes.function_call[chunk] == nil or
-                states.results.edge_indexes.function_call[chunk][statement_number] == nil then
-              if states.results.elided_function_call_edge_index[chunk] == nil or
-                  states.results.elided_function_call_edge_index[chunk][statement_number] == nil then
+            if states.results.edge_indexes.function_call_out[chunk] == nil or
+                states.results.edge_indexes.function_call_out[chunk][statement_number] == nil then
+              if states.results.elided_function_call_out_edge_index[statement] == nil then
                 local formatted_csname = format_csname(statement.used_csname.payload)
                 local byte_range = get_byte_range()
                 issues:add("e505", "calling an undefined function", byte_range, formatted_csname)
               end
             else
-              assert(#states.results.edge_indexes.function_call[chunk][statement_number] > 0)
+              assert(#states.results.edge_indexes.function_call_out[chunk][statement_number] > 0)
             end
           end
         end
@@ -1621,7 +1645,8 @@ local function cleanup(states, _, _)
   states.results.drew_dynamic_edges = nil
   states.results.drew_static_edges = nil
   states.results.edge_indexes = nil
-  states.results.elided_function_call_edge_index = nil
+  states.results.function_definition_in_edge_index = nil
+  states.results.elided_function_call_out_edge_index = nil
   states.results.reaching_definitions = nil
 end
 

--- a/explcheck/src/explcheck-flow-analysis.lua
+++ b/explcheck/src/explcheck-flow-analysis.lua
@@ -1162,32 +1162,24 @@ local function draw_group_wide_dynamic_edges(states, _, options)
               states.results.reaching_definitions.lists[chunk][macro_statement_number] ~= nil then
             local other_reaching_definition_index = states.results.reaching_definitions.indexes[chunk][macro_statement_number]
             local base_csname = statement.base_csname.payload
-            if other_reaching_definition_index[base_csname] == nil then
-              -- Elide calls to function definitions that are indirectly defined as well-know control sequences.
-              local state = states[function_call_chunk.segment.location.file_number]
-              local imported_prefixes = get_option('imported_prefixes', options, state.pathname)
-              local l3prefixes_max_first_registered_date = get_option("l3prefixes_max_first_registered_date", options, state.pathname)
-              local expl3_well_known_csname = parsers.expl3_well_known_csname(l3prefixes_max_first_registered_date, imported_prefixes)
-              if lpeg.match(expl3_well_known_csname, base_csname) ~= nil then
-                states.results.elided_function_call_out_edge_index[function_call_statement] = true
+            -- Elide calls to indirect function definitions and index those definitions.
+            states.results.elided_function_call_out_edge_index[function_call_statement] = true
+            states.results.function_definition_in_edge_index[statement] = true
+            for _, other_definition in ipairs(other_reaching_definition_index[base_csname] or {}) do
+              local other_chunk, other_macro_statement_number, other_statement_number
+                = other_definition.chunk, other_definition.macro_statement_number, other_definition.statement_number
+              local other_statement = get_statement(states, other_chunk, other_macro_statement_number, other_statement_number)
+              assert(is_well_behaved(other_statement))
+              assert(other_definition.csname == base_csname)
+              -- Weaken the base function definition confidence with the function variant definition confidence.
+              local combined_definition
+              if definition.confidence < other_definition.confidence then
+                combined_definition = make_shallow_copy(other_definition)
+                combined_definition.confidence = definition.confidence
+              else
+                combined_definition = other_definition
               end
-            else
-              for _, other_definition in ipairs(other_reaching_definition_index[base_csname] or {}) do
-                local other_chunk, other_macro_statement_number, other_statement_number
-                  = other_definition.chunk, other_definition.macro_statement_number, other_definition.statement_number
-                local other_statement = get_statement(states, other_chunk, other_macro_statement_number, other_statement_number)
-                assert(is_well_behaved(other_statement))
-                assert(other_definition.csname == base_csname)
-                -- Weaken the base function definition confidence with the function variant definition confidence.
-                local combined_definition
-                if definition.confidence < other_definition.confidence then
-                  combined_definition = make_shallow_copy(other_definition)
-                  combined_definition.confidence = definition.confidence
-                else
-                  combined_definition = other_definition
-                end
-                table.insert(reaching_function_and_variant_definition_list, combined_definition)
-              end
+              table.insert(reaching_function_and_variant_definition_list, combined_definition)
             end
           end
         else

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -931,7 +931,7 @@ local function collect_statements(states, file_number, options)
                 definition_token_range = definition_token_range,
                 maybe_used = false,
                 maybe_multiply_defined = false,
-                call_file_numbers = nil,  -- later filled in by `determine_function_calls_for_definitions()`
+                call_segments = nil,  -- later filled in by `determine_function_calls_for_definitions()`
                 -- The following attributes are specific to the subtype.
                 is_conditional = is_conditional,
                 is_protected = is_protected,
@@ -1009,7 +1009,7 @@ local function collect_statements(states, file_number, options)
                 definition_token_range = token_range,
                 maybe_used = false,
                 maybe_multiply_defined = false,
-                call_file_numbers = nil,  -- later filled in by `determine_function_calls_for_definitions()`
+                call_segments = nil,  -- later filled in by `determine_function_calls_for_definitions()`
                 -- The following attributes are specific to the subtype.
                 base_csname = effective_base_csname,
                 is_conditional = is_conditional,
@@ -1387,7 +1387,8 @@ local function analyze_group_wide_statements(states, _, options)
     defined_csname_texts_anywhere = {},
     defined_csname_texts_anywhere_file_numbers = {},
 
-    called_functions_anywhere_file_numbers = {},
+    called_functions_anywhere_segments_index = {},
+    called_functions_anywhere_segments_list = {},
 
     defined_message_nums_text_parameters = {},
 
@@ -1990,10 +1991,14 @@ local function analyze_group_wide_statements(states, _, options)
         elseif statement.type == OTHER_STATEMENT or statement.type == FUNCTION_CALL then
           -- Record control sequence name usage and definitions.
           for _, call in statement.call_range:enumerate(segment.calls) do
-            if states.results.statement_analysis.called_functions_anywhere_file_numbers[call.csname] == nil then
-              states.results.statement_analysis.called_functions_anywhere_file_numbers[call.csname] = {}
+            if states.results.statement_analysis.called_functions_anywhere_segments_index[call.csname] == nil then
+              states.results.statement_analysis.called_functions_anywhere_segments_index[call.csname] = {}
+              states.results.statement_analysis.called_functions_anywhere_segments_list[call.csname] = {}
             end
-            states.results.statement_analysis.called_functions_anywhere_file_numbers[call.csname][file_number] = true
+            if states.results.statement_analysis.called_functions_anywhere_segments_index[call.csname][segment] == nil then
+              states.results.statement_analysis.called_functions_anywhere_segments_index[call.csname][segment] = true
+              table.insert(states.results.statement_analysis.called_functions_anywhere_segments_list[call.csname], segment)
+            end
             states.results.statement_analysis.maybe_used_csname_texts[call.csname] = true
             local csname_byte_range = token_range_to_byte_range(call.csname_token_range)
             table.insert(results.statement_analysis.called_functions_and_variants, {segment, statement, call.csname, csname_byte_range})
@@ -2335,16 +2340,7 @@ local function determine_function_calls_for_definitions(states, file_number, _)
     assert(statement.type == FUNCTION_DEFINITION or statement.type == FUNCTION_VARIANT_DEFINITION)
     assert(statement.defined_csname.type == TEXT)
     local defined_csname = statement.defined_csname.payload
-    if states.results.statement_analysis.called_functions_anywhere_file_numbers[defined_csname] == nil then
-      goto next_statement
-    end
-    statement.call_file_numbers = {}
-    for call_file_number, _ in pairs(states.results.statement_analysis.called_functions_anywhere_file_numbers[defined_csname]) do
-      table.insert(statement.call_file_numbers, call_file_number)
-    end
-    assert(#statement.call_file_numbers > 0)
-    table.sort(statement.call_file_numbers)
-    ::next_statement::
+    statement.call_segments = states.results.statement_analysis.called_functions_anywhere_segments_list[defined_csname]
   end
 end
 

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -765,6 +765,7 @@ local function collect_statements(states, file_number, options)
               is_conditional = is_conditional,
               maybe_used = false,
               maybe_multiply_defined = false,
+              call_file_numbers = nil,  -- later filled in by `determine_function_calls_for_definitions()`
             }
             table.insert(statements, statement)
           end
@@ -930,6 +931,7 @@ local function collect_statements(states, file_number, options)
                 definition_token_range = definition_token_range,
                 maybe_used = false,
                 maybe_multiply_defined = false,
+                call_file_numbers = nil,  -- later filled in by `determine_function_calls_for_definitions()`
                 -- The following attributes are specific to the subtype.
                 is_conditional = is_conditional,
                 is_protected = is_protected,
@@ -1007,6 +1009,7 @@ local function collect_statements(states, file_number, options)
                 definition_token_range = token_range,
                 maybe_used = false,
                 maybe_multiply_defined = false,
+                call_file_numbers = nil,  -- later filled in by `determine_function_calls_for_definitions()`
                 -- The following attributes are specific to the subtype.
                 base_csname = effective_base_csname,
                 is_conditional = is_conditional,
@@ -1384,6 +1387,8 @@ local function analyze_group_wide_statements(states, _, options)
     defined_csname_texts_anywhere = {},
     defined_csname_texts_anywhere_file_numbers = {},
 
+    called_functions_anywhere_file_numbers = {},
+
     defined_message_nums_text_parameters = {},
 
     -- Collect group-wide information about symbols that may have been defined.
@@ -1451,6 +1456,7 @@ local function analyze_group_wide_statements(states, _, options)
       -- Index file-local statements.
       function_call_variant_definition_and_indirect_definition_list = {},
       non_redefined_function_and_variant_definition_list = {},
+      function_and_variant_definition_list = {},
     }
     for _, segment in ipairs(results.segments or {}) do
       assert(file_number == segment.location.file_number)
@@ -1708,6 +1714,7 @@ local function analyze_group_wide_statements(states, _, options)
           end
           -- Index the function variant definition.
           if statement.defined_csname.type == TEXT then
+            table.insert(results.statement_analysis.function_and_variant_definition_list, statement)
             if states.results.statement_analysis.function_definition_index[statement.defined_csname.payload] == nil then
               states.results.statement_analysis.function_definition_index[statement.defined_csname.payload] = {}
             end
@@ -1767,6 +1774,7 @@ local function analyze_group_wide_statements(states, _, options)
           end
           -- Index the function definition.
           if statement.defined_csname.type == TEXT then
+            table.insert(results.statement_analysis.function_and_variant_definition_list, statement)
             if states.results.statement_analysis.function_definition_index[statement.defined_csname.payload] == nil then
               states.results.statement_analysis.function_definition_index[statement.defined_csname.payload] = {}
             end
@@ -1982,6 +1990,10 @@ local function analyze_group_wide_statements(states, _, options)
         elseif statement.type == OTHER_STATEMENT or statement.type == FUNCTION_CALL then
           -- Record control sequence name usage and definitions.
           for _, call in statement.call_range:enumerate(segment.calls) do
+            if states.results.statement_analysis.called_functions_anywhere_file_numbers[call.csname] == nil then
+              states.results.statement_analysis.called_functions_anywhere_file_numbers[call.csname] = {}
+            end
+            states.results.statement_analysis.called_functions_anywhere_file_numbers[call.csname][file_number] = true
             states.results.statement_analysis.maybe_used_csname_texts[call.csname] = true
             local csname_byte_range = token_range_to_byte_range(call.csname_token_range)
             table.insert(results.statement_analysis.called_functions_and_variants, {segment, statement, call.csname, csname_byte_range})
@@ -2310,6 +2322,32 @@ local function report_issues(states, file_number, options)
   end
 end
 
+-- Determine and record the potential function calls for all function (variant) definitions.
+local function determine_function_calls_for_definitions(states, file_number, _)
+  assert(states.results.statement_analysis ~= nil)
+
+  local state = states[file_number]
+
+  local results = state.results
+  assert(results.statement_analysis ~= nil)
+
+  for _, statement in ipairs(results.statement_analysis.function_and_variant_definition_list) do
+    assert(statement.type == FUNCTION_DEFINITION or statement.type == FUNCTION_VARIANT_DEFINITION)
+    assert(statement.defined_csname.type == TEXT)
+    local defined_csname = statement.defined_csname.payload
+    if states.results.statement_analysis.called_functions_anywhere_file_numbers[defined_csname] == nil then
+      goto next_statement
+    end
+    statement.call_file_numbers = {}
+    for call_file_number, _ in pairs(states.results.statement_analysis.called_functions_anywhere_file_numbers[defined_csname]) do
+      table.insert(statement.call_file_numbers, call_file_number)
+    end
+    assert(#statement.call_file_numbers > 0)
+    table.sort(statement.call_file_numbers)
+    ::next_statement::
+  end
+end
+
 -- Determine which function (variant) (un)definitions might actually affect any function calls in the current file group.
 -- This information is used to exclude definitely unused (un)definitions from future analyses to improve performance.
 local function determine_maybe_used_function_definitions(states, file_number, _)
@@ -2442,6 +2480,7 @@ local substeps = {
   collect_statements,
   analyze_group_wide_statements,
   report_issues,
+  determine_function_calls_for_definitions,
   determine_maybe_multiply_defined_function_definitions,
   determine_maybe_used_function_definitions,
   cleanup,

--- a/explcheck/testfiles/w502.lua
+++ b/explcheck/testfiles/w502.lua
@@ -1,0 +1,26 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "w502.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 0)
+assert(#issues.warnings == 1)
+
+local expected_line_numbers = {{1, 3}}
+local expected_contexts = {[[\__module_foo:]]}
+for index, warning in ipairs(sort_issues(issues.warnings)) do
+  assert(warning[1] == "w502")
+  assert(warning[2] == "unused private function")
+  local byte_range = warning[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+  assert(warning[4] == expected_contexts[index])
+end

--- a/explcheck/testfiles/w502.lua
+++ b/explcheck/testfiles/w502.lua
@@ -12,7 +12,7 @@ local issues, results = state.issues, state.results
 assert(#issues.errors == 0)
 assert(#issues.warnings == 1)
 
-local expected_line_numbers = {{1, 3}}
+local expected_line_numbers = {{5, 7}}
 local expected_contexts = {[[\__module_foo:]]}
 for index, warning in ipairs(sort_issues(issues.warnings)) do
   assert(warning[1] == "w502")

--- a/explcheck/testfiles/w502.tex
+++ b/explcheck/testfiles/w502.tex
@@ -1,0 +1,6 @@
+\cs_new:Nn  % warning on this line
+  \__module_foo:
+  { bar }
+\cs_new:Nn
+  \module_baz:
+  { \__module_foo: }

--- a/explcheck/testfiles/w502.tex
+++ b/explcheck/testfiles/w502.tex
@@ -1,6 +1,7 @@
-\cs_new:Nn  % warning on this line
+\cs_new:Nn
+  \__module_foo:
+  { foo }
+\__module_foo:
+\cs_gset:Nn  % warning on this line
   \__module_foo:
   { bar }
-\cs_new:Nn
-  \module_baz:
-  { \__module_foo: }

--- a/explcheck/testfiles/w503.lua
+++ b/explcheck/testfiles/w503.lua
@@ -1,0 +1,26 @@
+local sort_issues = require("explcheck-issues").sort_issues
+local utils = require("explcheck-utils")
+
+local filename = "w503.tex"
+local options = {
+  expl3_detection_strategy = "always",
+  stop_after = "flow analysis",
+}
+local state = table.unpack(utils.process_files({filename}, options))
+local issues, results = state.issues, state.results
+
+assert(#issues.errors == 0)
+assert(#issues.warnings == 1)
+
+local expected_line_numbers = {{13, 15}}
+local expected_contexts = {[[\__module_foo:V]]}
+for index, warning in ipairs(sort_issues(issues.warnings)) do
+  assert(warning[1] == "w503")
+  assert(warning[2] == "unused private function variant")
+  local byte_range = warning[3]
+  local start_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:start())
+  local end_line_number = utils.convert_byte_to_line_and_column(results.line_starting_byte_numbers, byte_range:stop())
+  assert(start_line_number == expected_line_numbers[index][1])
+  assert(end_line_number == expected_line_numbers[index][2])
+  assert(warning[4] == expected_contexts[index])
+end

--- a/explcheck/testfiles/w503.lua
+++ b/explcheck/testfiles/w503.lua
@@ -12,7 +12,7 @@ local issues, results = state.issues, state.results
 assert(#issues.errors == 0)
 assert(#issues.warnings == 1)
 
-local expected_line_numbers = {{13, 15}}
+local expected_line_numbers = {{14, 16}}
 local expected_contexts = {[[\__module_foo:V]]}
 for index, warning in ipairs(sort_issues(issues.warnings)) do
   assert(warning[1] == "w503")

--- a/explcheck/testfiles/w503.tex
+++ b/explcheck/testfiles/w503.tex
@@ -1,0 +1,17 @@
+\cs_new:Nn
+  \__module_foo:n
+  { bar }
+\cs_new:Nn
+  \module_baz:
+  {
+    \tl_set:Nn
+      \l_tmpa_tl
+      { baz }
+    \__module_foo:V
+      \l_tmpa_tl
+  }
+\cs_generate_variant:Nn  % warning on this line
+  \__module_foo:n
+  { V }
+\__module_foo:n
+  { baz }

--- a/explcheck/testfiles/w503.tex
+++ b/explcheck/testfiles/w503.tex
@@ -1,17 +1,16 @@
 \cs_new:Nn
   \__module_foo:n
   { bar }
-\cs_new:Nn
-  \module_baz:
-  {
-    \tl_set:Nn
-      \l_tmpa_tl
-      { baz }
-    \__module_foo:V
-      \l_tmpa_tl
-  }
+\cs_generate_variant:Nn
+  \__module_foo:n
+  { V }
+\tl_set:Nn
+  \l_tmpa_tl
+  { baz }
+\__module_foo:V
+  \l_tmpa_tl
+\cs_undefine:N
+  \__module_foo:V
 \cs_generate_variant:Nn  % warning on this line
   \__module_foo:n
   { V }
-\__module_foo:n
-  { baz }


### PR DESCRIPTION
This PR continues #188 based on the tasks outlined there:

- [ ] Report issues from _Section 5.1 (Functions and conditional functions)_ from the document titled [_Warnings and errors for the expl3 analysis tool_](https://github.com/witiko/expltools/releases/download/latest/warnings-and-errors.pdf):
    - [x] Report issues that we can report by adding new data-flow analyses:
        - [x] Report issues _W502 (Unused private function)_ and _W503 (Unused private function variant)_.
    - [ ] Report issues that we can report by updating the semantic analysis and adding new data-flow analyses:
        - [ ] Report issues _E508 (Unexpandable or restricted-expandable boolean expression)_, _E509 (Expanding an unexpandable function)_, _E510 (Fully-expanding a restricted-expandable function)_, and _W512 (Defined an unexpandable function as unprotected)_.
        - [ ] Report issue _W511 (Defined an expandable function as protected)_.
        - [ ] Report issues _E513 (Conditional function with no return value)_ and _E514 (Conditional function with no return value)_.
        - [ ] Report issue _E515 (Comparison code with no return value)_.
        - [ ] Report issue _E516 (Paragraph token in the parameter of a "nopar" function)_.
- [x] Update the file `CHANGES.md`.