### PR TITLE
Do not report issue W415 (Unused variable or constant) for defined box variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,16 @@ This version of explcheck has implemented the following new features:
   from boolean variable and constant definitions, not calls like `\bool_if:nTF`
   and others.
 
+#### Fixes
+
+This version of explcheck has fixed the following problems:
+
+- Do not report issue W415 (Unused variable or constant) for defined box
+  variables. (reported by @dcpurton in #214, fixed in #216)
+
+  Defining box variables can have useful side effects even if the variable
+  isn't used elsewhere.
+
 #### Warnings and errors
 
 This version of explcheck has made the following changes to the document titled

--- a/explcheck/src/explcheck-semantic-analysis.lua
+++ b/explcheck/src/explcheck-semantic-analysis.lua
@@ -2002,6 +2002,10 @@ local function analyze_group_wide_statements(states, _, options)
                 results.statement_analysis.declared_variable_csname_texts,
                 {statement.defined_csname.payload, defined_csname_byte_range}
               )
+            elseif statement.variable_type == "box" or statement.variable_type == "vbox" or statement.variable_type == "hbox" then
+              -- Defining box variables can have useful side effects even if the variable isn't used elsewhere.
+              -- Therefore, consider defined box variables to be used for the purpose of issue reporting.
+              states.results.statement_analysis.maybe_used_variable_csname_texts[statement.defined_csname.payload] = true
             end
           end
           -- Record control sequence name usage and definitions.

--- a/explcheck/testfiles/TL2025-issues/w415.txt
+++ b/explcheck/testfiles/TL2025-issues/w415.txt
@@ -235,5 +235,4 @@
 /usr/local/texlive/2025/texmf-dist/tex/xelatex/xduts/xduugtp.cls
 /usr/local/texlive/2025/texmf-dist/tex/xelatex/xecjk/xeCJK.sty
 /usr/local/texlive/2025/texmf-dist/tex/xelatex/xepersian-hm/xepersian-hm.sty
-/usr/local/texlive/2025/texmf-dist/tex/xelatex/xltxtra/xltxtra.sty
 /usr/local/texlive/2025/texmf-dist/tex/xelatex/zitie/zitie.sty

--- a/explcheck/testfiles/regression-issue-214.tex
+++ b/explcheck/testfiles/regression-issue-214.tex
@@ -1,0 +1,14 @@
+\ProvidesExplPackage{test}{2026-05-18}{1.0}{Test Package (DCP)}
+\box_new:N \l_dcp_test_box
+\cs_new_protected:Nn \dcp_test_function:
+  {
+    \vbox_set:Nn \l_dcp_test_box
+      {
+        \hbox:n { First ~ Line }
+        \hbox:n { Second ~ Line }
+        \par
+        \box_set_to_last:N \l_tmpa_box
+        \dim_gset:Nn \g_tmpa_dim { \box_wd:N \l_tmpa_box }
+      }
+    \dim_use:N \g_tmpa_dim
+  }


### PR DESCRIPTION
Defining box variables can have useful side effects even if the variable isn't used elsewhere. After this PR, the issue W415 (Unused variable or constant) isn't reported for box variables that are defined but unused.

Closes https://github.com/Witiko/expltools/issues/214.