### PR TITLE
Update `CHANGES.md`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,8 +104,6 @@ submodules and other dependencies:
 
 - Update the `latex3` submodule from 2026-04-28-dev to 2026-05-15-dev. (85b126a)
 
-### explcheck v0.22.0
-
 ## expltools 2026-05-12
 
 ### explcheck v0.21.0


### PR DESCRIPTION
There were two `### explcheck v0.22.0` section titles in the `CHANGES.md`.
This PR removes the second, superfluous one.